### PR TITLE
VIP to adjust risk params and reduce SXP reserves

### DIFF
--- a/simulations/vip-117/abi/IERC20UpgradableAbi.json
+++ b/simulations/vip-117/abi/IERC20UpgradableAbi.json
@@ -1,0 +1,295 @@
+[
+  {
+    "inputs": [
+      { "internalType": "string", "name": "name_", "type": "string" },
+      { "internalType": "string", "name": "symbol_", "type": "string" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "spender", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "userAddress", "type": "address" },
+      { "indexed": false, "internalType": "address payable", "name": "relayerAddress", "type": "address" },
+      { "indexed": false, "internalType": "bytes", "name": "functionSignature", "type": "bytes" }
+    ],
+    "name": "MetaTransactionExecuted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "indexed": true, "internalType": "bytes32", "name": "previousAdminRole", "type": "bytes32" },
+      { "indexed": true, "internalType": "bytes32", "name": "newAdminRole", "type": "bytes32" }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "account", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "sender", "type": "address" }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "account", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "sender", "type": "address" }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ERC712_VERSION",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PREDICATE_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "subtractedValue", "type": "uint256" }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "userAddress", "type": "address" },
+      { "internalType": "bytes", "name": "functionSignature", "type": "bytes" },
+      { "internalType": "bytes32", "name": "sigR", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "sigS", "type": "bytes32" },
+      { "internalType": "uint8", "name": "sigV", "type": "uint8" }
+    ],
+    "name": "executeMetaTransaction",
+    "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getChainId",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getDomainSeperator",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "user", "type": "address" }],
+    "name": "getNonce",
+    "outputs": [{ "internalType": "uint256", "name": "nonce", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "role", "type": "bytes32" }],
+    "name": "getRoleAdmin",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "uint256", "name": "index", "type": "uint256" }
+    ],
+    "name": "getRoleMember",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "role", "type": "bytes32" }],
+    "name": "getRoleMemberCount",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "hasRole",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "addedValue", "type": "uint256" }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "sender", "type": "address" },
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/simulations/vip-117/abi/VBep20Abi.json
+++ b/simulations/vip-117/abi/VBep20Abi.json
@@ -1,0 +1,692 @@
+[
+  { "inputs": [], "payable": false, "stateMutability": "nonpayable", "type": "constructor" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "cashPrior", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "interestAccumulated", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "borrowIndex", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "AccrueInterest",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "spender", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "borrowAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBorrows", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "Borrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "error", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "info", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "detail", "type": "uint256" }
+    ],
+    "name": "Failure",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "liquidator", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "address", "name": "vTokenCollateral", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "LiquidateBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "minter", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "mintAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "mintTokens", "type": "uint256" }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldAdmin", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newAdmin", "type": "address" }
+    ],
+    "name": "NewAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract ComptrollerInterface",
+        "name": "oldComptroller",
+        "type": "address"
+      },
+      { "indexed": false, "internalType": "contract ComptrollerInterface", "name": "newComptroller", "type": "address" }
+    ],
+    "name": "NewComptroller",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract InterestRateModel",
+        "name": "oldInterestRateModel",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract InterestRateModel",
+        "name": "newInterestRateModel",
+        "type": "address"
+      }
+    ],
+    "name": "NewMarketInterestRateModel",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldPendingAdmin", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newPendingAdmin", "type": "address" }
+    ],
+    "name": "NewPendingAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldReserveFactorMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newReserveFactorMantissa", "type": "uint256" }
+    ],
+    "name": "NewReserveFactor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "redeemer", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "redeemAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }
+    ],
+    "name": "Redeem",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "redeemer", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "feeAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }
+    ],
+    "name": "RedeemFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "payer", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBorrows", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "RepayBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "benefactor", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "addAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newTotalReserves", "type": "uint256" }
+    ],
+    "name": "ReservesAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "admin", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "reduceAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newTotalReserves", "type": "uint256" }
+    ],
+    "name": "ReservesReduced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "_acceptAdmin",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "addAmount", "type": "uint256" }],
+    "name": "_addReserves",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "bytes", "name": "data", "type": "bytes" }],
+    "name": "_becomeImplementation",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "reduceAmount", "type": "uint256" }],
+    "name": "_reduceReserves",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "_resignImplementation",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "contract ComptrollerInterface", "name": "newComptroller", "type": "address" }],
+    "name": "_setComptroller",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "contract InterestRateModel", "name": "newInterestRateModel", "type": "address" }],
+    "name": "_setInterestRateModel",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address payable", "name": "newPendingAdmin", "type": "address" }],
+    "name": "_setPendingAdmin",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "newReserveFactorMantissa", "type": "uint256" }],
+    "name": "_setReserveFactor",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "accrualBlockNumber",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "accrueInterest",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "admin",
+    "outputs": [{ "internalType": "address payable", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "balanceOfUnderlying",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }],
+    "name": "borrow",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "borrowBalanceCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "borrowBalanceStored",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "borrowIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "borrowRatePerBlock",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "comptroller",
+    "outputs": [{ "internalType": "contract ComptrollerInterface", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "exchangeRateCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "exchangeRateStored",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "getAccountSnapshot",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getCash",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "implementation",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "underlying_", "type": "address" },
+      { "internalType": "contract ComptrollerInterface", "name": "comptroller_", "type": "address" },
+      { "internalType": "contract InterestRateModel", "name": "interestRateModel_", "type": "address" },
+      { "internalType": "uint256", "name": "initialExchangeRateMantissa_", "type": "uint256" },
+      { "internalType": "string", "name": "name_", "type": "string" },
+      { "internalType": "string", "name": "symbol_", "type": "string" },
+      { "internalType": "uint8", "name": "decimals_", "type": "uint8" }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "contract ComptrollerInterface", "name": "comptroller_", "type": "address" },
+      { "internalType": "contract InterestRateModel", "name": "interestRateModel_", "type": "address" },
+      { "internalType": "uint256", "name": "initialExchangeRateMantissa_", "type": "uint256" },
+      { "internalType": "string", "name": "name_", "type": "string" },
+      { "internalType": "string", "name": "symbol_", "type": "string" },
+      { "internalType": "uint8", "name": "decimals_", "type": "uint8" }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "interestRateModel",
+    "outputs": [{ "internalType": "contract InterestRateModel", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "isVToken",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "internalType": "contract VTokenInterface", "name": "vTokenCollateral", "type": "address" }
+    ],
+    "name": "liquidateBorrow",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "mintAmount", "type": "uint256" }],
+    "name": "mint",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pendingAdmin",
+    "outputs": [{ "internalType": "address payable", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }],
+    "name": "redeem",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "redeemAmount", "type": "uint256" }],
+    "name": "redeemUnderlying",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "repayAmount", "type": "uint256" }],
+    "name": "repayBorrow",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "repayBorrowBehalf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "reserveFactorMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "seize",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "supplyRatePerBlock",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalBorrows",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "totalBorrowsCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalReserves",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "src", "type": "address" },
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "underlying",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/simulations/vip-117/abi/comptroller.json
+++ b/simulations/vip-117/abi/comptroller.json
@@ -1,0 +1,1339 @@
+[
+  { "inputs": [], "payable": false, "stateMutability": "nonpayable", "type": "constructor" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": true, "internalType": "enum ComptrollerV9Storage.Action", "name": "action", "type": "uint8" },
+      { "indexed": false, "internalType": "bool", "name": "pauseState", "type": "bool" }
+    ],
+    "name": "ActionPausedMarket",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "bool", "name": "state", "type": "bool" }],
+    "name": "ActionProtocolPaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "delegate", "type": "address" },
+      { "indexed": false, "internalType": "bool", "name": "allowDelegatedBorrows", "type": "bool" }
+    ],
+    "name": "DelegateUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "venusDelta", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "venusBorrowIndex", "type": "uint256" }
+    ],
+    "name": "DistributedBorrowerVenus",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "supplier", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "venusDelta", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "venusSupplyIndex", "type": "uint256" }
+    ],
+    "name": "DistributedSupplierVenus",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }],
+    "name": "DistributedVAIVaultVenus",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "error", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "info", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "detail", "type": "uint256" }
+    ],
+    "name": "Failure",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "MarketEntered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "MarketExited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "contract VToken", "name": "vToken", "type": "address" }],
+    "name": "MarketListed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldAccessControlAddress", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newAccessControlAddress", "type": "address" }
+    ],
+    "name": "NewAccessControl",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "newBorrowCap", "type": "uint256" }
+    ],
+    "name": "NewBorrowCap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldCloseFactorMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newCloseFactorMantissa", "type": "uint256" }
+    ],
+    "name": "NewCloseFactor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "oldCollateralFactorMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newCollateralFactorMantissa", "type": "uint256" }
+    ],
+    "name": "NewCollateralFactor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldComptrollerLens", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newComptrollerLens", "type": "address" }
+    ],
+    "name": "NewComptrollerLens",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldLiquidationIncentiveMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newLiquidationIncentiveMantissa", "type": "uint256" }
+    ],
+    "name": "NewLiquidationIncentive",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldLiquidatorContract", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newLiquidatorContract", "type": "address" }
+    ],
+    "name": "NewLiquidatorContract",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldPauseGuardian", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newPauseGuardian", "type": "address" }
+    ],
+    "name": "NewPauseGuardian",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "contract PriceOracle", "name": "oldPriceOracle", "type": "address" },
+      { "indexed": false, "internalType": "contract PriceOracle", "name": "newPriceOracle", "type": "address" }
+    ],
+    "name": "NewPriceOracle",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "newSupplyCap", "type": "uint256" }
+    ],
+    "name": "NewSupplyCap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldTreasuryAddress", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newTreasuryAddress", "type": "address" }
+    ],
+    "name": "NewTreasuryAddress",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldTreasuryGuardian", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newTreasuryGuardian", "type": "address" }
+    ],
+    "name": "NewTreasuryGuardian",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldTreasuryPercent", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newTreasuryPercent", "type": "uint256" }
+    ],
+    "name": "NewTreasuryPercent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract VAIControllerInterface",
+        "name": "oldVAIController",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract VAIControllerInterface",
+        "name": "newVAIController",
+        "type": "address"
+      }
+    ],
+    "name": "NewVAIController",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldVAIMintRate", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newVAIMintRate", "type": "uint256" }
+    ],
+    "name": "NewVAIMintRate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "vault_", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "releaseStartBlock_", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "releaseInterval_", "type": "uint256" }
+    ],
+    "name": "NewVAIVaultInfo",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldVenusVAIVaultRate", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newVenusVAIVaultRate", "type": "uint256" }
+    ],
+    "name": "NewVenusVAIVaultRate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "newSpeed", "type": "uint256" }
+    ],
+    "name": "VenusBorrowSpeedUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "recipient", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "VenusGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "newSpeed", "type": "uint256" }
+    ],
+    "name": "VenusSupplySpeedUpdated",
+    "type": "event"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "contract Unitroller", "name": "unitroller", "type": "address" }],
+    "name": "_become",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "_grantXVS",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "newAccessControlAddress", "type": "address" }],
+    "name": "_setAccessControl",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address[]", "name": "markets", "type": "address[]" },
+      { "internalType": "enum ComptrollerV9Storage.Action[]", "name": "actions", "type": "uint8[]" },
+      { "internalType": "bool", "name": "paused", "type": "bool" }
+    ],
+    "name": "_setActionsPaused",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "newCloseFactorMantissa", "type": "uint256" }],
+    "name": "_setCloseFactor",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "internalType": "uint256", "name": "newCollateralFactorMantissa", "type": "uint256" }
+    ],
+    "name": "_setCollateralFactor",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "contract ComptrollerLensInterface", "name": "comptrollerLens_", "type": "address" }],
+    "name": "_setComptrollerLens",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "newLiquidationIncentiveMantissa", "type": "uint256" }],
+    "name": "_setLiquidationIncentive",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "newLiquidatorContract_", "type": "address" }],
+    "name": "_setLiquidatorContract",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "contract VToken[]", "name": "vTokens", "type": "address[]" },
+      { "internalType": "uint256[]", "name": "newBorrowCaps", "type": "uint256[]" }
+    ],
+    "name": "_setMarketBorrowCaps",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "contract VToken[]", "name": "vTokens", "type": "address[]" },
+      { "internalType": "uint256[]", "name": "newSupplyCaps", "type": "uint256[]" }
+    ],
+    "name": "_setMarketSupplyCaps",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "newPauseGuardian", "type": "address" }],
+    "name": "_setPauseGuardian",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "contract PriceOracle", "name": "newOracle", "type": "address" }],
+    "name": "_setPriceOracle",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "bool", "name": "state", "type": "bool" }],
+    "name": "_setProtocolPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "newTreasuryGuardian", "type": "address" },
+      { "internalType": "address", "name": "newTreasuryAddress", "type": "address" },
+      { "internalType": "uint256", "name": "newTreasuryPercent", "type": "uint256" }
+    ],
+    "name": "_setTreasuryData",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "contract VAIControllerInterface", "name": "vaiController_", "type": "address" }],
+    "name": "_setVAIController",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "newVAIMintRate", "type": "uint256" }],
+    "name": "_setVAIMintRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vault_", "type": "address" },
+      { "internalType": "uint256", "name": "releaseStartBlock_", "type": "uint256" },
+      { "internalType": "uint256", "name": "minReleaseAmount_", "type": "uint256" }
+    ],
+    "name": "_setVAIVaultInfo",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "contract VToken[]", "name": "vTokens", "type": "address[]" },
+      { "internalType": "uint256[]", "name": "supplySpeeds", "type": "uint256[]" },
+      { "internalType": "uint256[]", "name": "borrowSpeeds", "type": "uint256[]" }
+    ],
+    "name": "_setVenusSpeeds",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "venusVAIVaultRate_", "type": "uint256" }],
+    "name": "_setVenusVAIVaultRate",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "contract VToken", "name": "vToken", "type": "address" }],
+    "name": "_supportMarket",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "name": "accountAssets",
+    "outputs": [{ "internalType": "contract VToken", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "market", "type": "address" },
+      { "internalType": "enum ComptrollerV9Storage.Action", "name": "action", "type": "uint8" }
+    ],
+    "name": "actionPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "admin",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "allMarkets",
+    "outputs": [{ "internalType": "contract VToken", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "approvedDelegates",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }
+    ],
+    "name": "borrowAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "borrowCapGuardian",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "borrowCaps",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }
+    ],
+    "name": "borrowVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "contract VToken", "name": "vToken", "type": "address" }
+    ],
+    "name": "checkMembership",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address[]", "name": "holders", "type": "address[]" },
+      { "internalType": "contract VToken[]", "name": "vTokens", "type": "address[]" },
+      { "internalType": "bool", "name": "borrowers", "type": "bool" },
+      { "internalType": "bool", "name": "suppliers", "type": "bool" },
+      { "internalType": "bool", "name": "collateral", "type": "bool" }
+    ],
+    "name": "claimVenus",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "holder", "type": "address" },
+      { "internalType": "contract VToken[]", "name": "vTokens", "type": "address[]" }
+    ],
+    "name": "claimVenus",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "holder", "type": "address" }],
+    "name": "claimVenus",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address[]", "name": "holders", "type": "address[]" },
+      { "internalType": "contract VToken[]", "name": "vTokens", "type": "address[]" },
+      { "internalType": "bool", "name": "borrowers", "type": "bool" },
+      { "internalType": "bool", "name": "suppliers", "type": "bool" }
+    ],
+    "name": "claimVenus",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "holder", "type": "address" }],
+    "name": "claimVenusAsCollateral",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "closeFactorMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "comptrollerImplementation",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "comptrollerLens",
+    "outputs": [{ "internalType": "contract ComptrollerLensInterface", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address[]", "name": "vTokens", "type": "address[]" }],
+    "name": "enterMarkets",
+    "outputs": [{ "internalType": "uint256[]", "name": "", "type": "uint256[]" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "vTokenAddress", "type": "address" }],
+    "name": "exitMarket",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "getAccountLiquidity",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getAllMarkets",
+    "outputs": [{ "internalType": "contract VToken[]", "name": "", "type": "address[]" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "getAssetsIn",
+    "outputs": [{ "internalType": "contract VToken[]", "name": "", "type": "address[]" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getBlockNumber",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "address", "name": "vTokenModify", "type": "address" },
+      { "internalType": "uint256", "name": "redeemTokens", "type": "uint256" },
+      { "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }
+    ],
+    "name": "getHypotheticalAccountLiquidity",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getXVSAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getXVSVTokenAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "isComptroller",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vTokenBorrowed", "type": "address" },
+      { "internalType": "address", "name": "vTokenCollateral", "type": "address" },
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "liquidateBorrowAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vTokenBorrowed", "type": "address" },
+      { "internalType": "address", "name": "vTokenCollateral", "type": "address" },
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "actualRepayAmount", "type": "uint256" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "liquidateBorrowVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "vTokenBorrowed", "type": "address" },
+      { "internalType": "address", "name": "vTokenCollateral", "type": "address" },
+      { "internalType": "uint256", "name": "actualRepayAmount", "type": "uint256" }
+    ],
+    "name": "liquidateCalculateSeizeTokens",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "vTokenCollateral", "type": "address" },
+      { "internalType": "uint256", "name": "actualRepayAmount", "type": "uint256" }
+    ],
+    "name": "liquidateVAICalculateSeizeTokens",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "liquidationIncentiveMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "liquidatorContract",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "markets",
+    "outputs": [
+      { "internalType": "bool", "name": "isListed", "type": "bool" },
+      { "internalType": "uint256", "name": "collateralFactorMantissa", "type": "uint256" },
+      { "internalType": "bool", "name": "isVenus", "type": "bool" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "maxAssets",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "minReleaseAmount",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "minter", "type": "address" },
+      { "internalType": "uint256", "name": "mintAmount", "type": "uint256" }
+    ],
+    "name": "mintAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "mintVAIGuardianPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "minter", "type": "address" },
+      { "internalType": "uint256", "name": "actualMintAmount", "type": "uint256" },
+      { "internalType": "uint256", "name": "mintTokens", "type": "uint256" }
+    ],
+    "name": "mintVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "mintedVAIs",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "oracle",
+    "outputs": [{ "internalType": "contract PriceOracle", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pauseGuardian",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pendingAdmin",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pendingComptrollerImplementation",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "protocolPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "redeemer", "type": "address" },
+      { "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }
+    ],
+    "name": "redeemAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "redeemer", "type": "address" },
+      { "internalType": "uint256", "name": "redeemAmount", "type": "uint256" },
+      { "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }
+    ],
+    "name": "redeemVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "releaseStartBlock",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "releaseToVault",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "payer", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "repayBorrowAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "payer", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "actualRepayAmount", "type": "uint256" },
+      { "internalType": "uint256", "name": "borrowerIndex", "type": "uint256" }
+    ],
+    "name": "repayBorrowVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "repayVAIGuardianPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vTokenCollateral", "type": "address" },
+      { "internalType": "address", "name": "vTokenBorrowed", "type": "address" },
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "seizeAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vTokenCollateral", "type": "address" },
+      { "internalType": "address", "name": "vTokenBorrowed", "type": "address" },
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "seizeVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "setMintedVAIOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "supplyCaps",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "src", "type": "address" },
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "transferTokens", "type": "uint256" }
+    ],
+    "name": "transferAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "src", "type": "address" },
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "transferTokens", "type": "uint256" }
+    ],
+    "name": "transferVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "treasuryAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "treasuryGuardian",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "treasuryPercent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "delegate", "type": "address" },
+      { "internalType": "bool", "name": "allowBorrows", "type": "bool" }
+    ],
+    "name": "updateDelegate",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "vaiController",
+    "outputs": [{ "internalType": "contract VAIControllerInterface", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "vaiMintRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "vaiVaultAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "venusAccrued",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "venusBorrowSpeeds",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "venusBorrowState",
+    "outputs": [
+      { "internalType": "uint224", "name": "index", "type": "uint224" },
+      { "internalType": "uint32", "name": "block", "type": "uint32" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "venusBorrowerIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "venusInitialIndex",
+    "outputs": [{ "internalType": "uint224", "name": "", "type": "uint224" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "venusRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "venusSpeeds",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "venusSupplierIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "venusSupplySpeeds",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "venusSupplyState",
+    "outputs": [
+      { "internalType": "uint224", "name": "index", "type": "uint224" },
+      { "internalType": "uint32", "name": "block", "type": "uint32" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "venusVAIVaultRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/simulations/vip-117/simulations.ts
+++ b/simulations/vip-117/simulations.ts
@@ -1,0 +1,73 @@
+import { expect } from "chai";
+import { parseUnits } from "ethers/lib/utils";
+import { ethers } from "hardhat";
+
+import { expectEvents, setMaxStalePeriodInOracle } from "../../src/utils";
+import { forking, testVip } from "../../src/vip-framework";
+import { vip117 } from "../../vips/vip-117";
+import IERC20_ABI from "./abi/IERC20UpgradableAbi.json";
+import VSXP_ABI from "./abi/VBep20Abi.json";
+import COMPTROLLER_ABI from "./abi/comptroller.json";
+
+const COMPTROLLER = "0xfd36e2c2a6789db23113685031d7f16329158384";
+const NEW_VTRX = "0xC5D3466aA484B040eE977073fcF337f2c00071c1";
+const VSXP = "0x2fF3d0F6990a40261c66E1ff2017aCBc282EB6d0";
+const SXP = "0x47BEAd2563dCBf3bF2c9407fEa4dC236fAbA485A";
+const TREASURY = "0xF322942f644A996A617BD29c16bd7d231d9F35E9";
+
+forking(28148357, () => {
+  let comptroller: ethers.Contract;
+  let sxpContract: ethers.Contract;
+  const provider = ethers.provider;
+
+  before(async () => {
+    comptroller = new ethers.Contract(COMPTROLLER, COMPTROLLER_ABI, provider);
+    sxpContract = await ethers.getContractAt(IERC20_ABI, SXP);
+    await setMaxStalePeriodInOracle(COMPTROLLER);
+  });
+
+  describe("Pre-VIP behavior", async () => {
+    it("collateral factor of TRX (new) equals 50%", async () => {
+      const collateralFactor = (await comptroller.markets(NEW_VTRX)).collateralFactorMantissa;
+      expect(collateralFactor).to.equal(parseUnits("0.50", 18));
+    });
+
+    it("collateral factor of SXP equals 12.5%", async () => {
+      const collateralFactor = (await comptroller.markets(VSXP)).collateralFactorMantissa;
+      expect(collateralFactor).to.equal(parseUnits("0.125", 18));
+    });
+
+    it("balance of SXP in the treasury", async () => {
+      const sxpTreasuryBalance = await sxpContract.balanceOf(TREASURY);
+      expect(sxpTreasuryBalance).to.equal("25610823482588636519545");
+    });
+  });
+
+  testVip("VIP-117 Risk Parameters Update", vip117(), {
+    callbackAfterExecution: async txResponse => {
+      await expectEvents(
+        txResponse,
+        [COMPTROLLER_ABI, VSXP_ABI],
+        ["NewCollateralFactor", "ReservesReduced", "Failure"],
+        [2, 1, 0],
+      );
+    },
+  });
+
+  describe("Post-VIP behavior", async () => {
+    it("collateral factor of TRX (new) equals 52.5%", async () => {
+      const collateralFactor = (await comptroller.markets(NEW_VTRX)).collateralFactorMantissa;
+      expect(collateralFactor).to.equal(parseUnits("0.525", 18));
+    });
+
+    it("collateral factor of SXP  equals 0%", async () => {
+      const collateralFactor = (await comptroller.markets(VSXP)).collateralFactorMantissa;
+      expect(collateralFactor).to.equal(0);
+    });
+
+    it("balance of SXP in the treasury", async () => {
+      const sxpTreasuryBalance = await sxpContract.balanceOf(TREASURY);
+      expect(sxpTreasuryBalance).to.equal("26137012855296712152656"); // 25610823482588636519545 + 526189372708075633111
+    });
+  });
+});

--- a/vips/vip-117.ts
+++ b/vips/vip-117.ts
@@ -1,0 +1,57 @@
+import { parseUnits } from "ethers/lib/utils";
+
+import { ProposalType } from "../src/types";
+import { makeProposal } from "../src/utils";
+
+const COMPTROLLER = "0xfd36e2c2a6789db23113685031d7f16329158384";
+const NEW_VTRX = "0xC5D3466aA484B040eE977073fcF337f2c00071c1";
+const VSXP = "0x2fF3d0F6990a40261c66E1ff2017aCBc282EB6d0";
+const SXP = "0x47BEAd2563dCBf3bF2c9407fEa4dC236fAbA485A";
+const VSXP_RESERVES = "526189372708075633111";
+const TREASURY = "0xF322942f644A996A617BD29c16bd7d231d9F35E9";
+
+export const vip117 = () => {
+  const meta = {
+    version: "v2",
+    title: "VIP-117 Risk Parameters Update",
+    description: `
+    TRX:
+        Increase CF to 0.525 from 0.50
+    SXP:
+        Decrease CF to 0.0 from 0.125
+    Reduce reserves in the SXP market
+      `,
+    forDescription: "I agree that Venus Protocol should proceed with the Risk Parameters Update's",
+    againstDescription: "I do not think that Venus Protocol should proceed with the Risk Parameters Update's",
+    abstainDescription: "I am indifferent to whether Venus Protocol proceeds with the Risk Parameters Update's or not",
+  };
+
+  return makeProposal(
+    [
+      {
+        target: COMPTROLLER,
+        signature: "_setCollateralFactor(address,uint256)",
+        params: [NEW_VTRX, parseUnits("0.525", 18)],
+      },
+
+      {
+        target: COMPTROLLER,
+        signature: "_setCollateralFactor(address,uint256)",
+        params: [VSXP, 0],
+      },
+
+      {
+        target: VSXP,
+        signature: "_reduceReserves(uint256)",
+        params: [VSXP_RESERVES],
+      },
+      {
+        target: SXP,
+        signature: "transfer(address,uint256)",
+        params: [TREASURY, VSXP_RESERVES],
+      },
+    ],
+    meta,
+    ProposalType.REGULAR,
+  );
+};


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->

Resolves VEN-1453

Related to https://github.com/VenusProtocol/vips/pull/15. After canceling https://app.venus.io/governance/proposal/116, let's propose the following changes:

    TRX:
        Increase CF to 0.525 from 0.50
    SXP:
        Decrease CF to 0.0 from 0.125

Moreover, we are reducing the reserves from the SXP markets, and transferring them to the Treasury contract
