### PR TITLE
add simulations for vip-138 payment to auditors

### DIFF
--- a/simulations/vip-138/abi/IERC20UpgradableAbi.json
+++ b/simulations/vip-138/abi/IERC20UpgradableAbi.json
@@ -1,0 +1,295 @@
+[
+  {
+    "inputs": [
+      { "internalType": "string", "name": "name_", "type": "string" },
+      { "internalType": "string", "name": "symbol_", "type": "string" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "spender", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "userAddress", "type": "address" },
+      { "indexed": false, "internalType": "address payable", "name": "relayerAddress", "type": "address" },
+      { "indexed": false, "internalType": "bytes", "name": "functionSignature", "type": "bytes" }
+    ],
+    "name": "MetaTransactionExecuted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "indexed": true, "internalType": "bytes32", "name": "previousAdminRole", "type": "bytes32" },
+      { "indexed": true, "internalType": "bytes32", "name": "newAdminRole", "type": "bytes32" }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "account", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "sender", "type": "address" }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "account", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "sender", "type": "address" }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ERC712_VERSION",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PREDICATE_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "subtractedValue", "type": "uint256" }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "userAddress", "type": "address" },
+      { "internalType": "bytes", "name": "functionSignature", "type": "bytes" },
+      { "internalType": "bytes32", "name": "sigR", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "sigS", "type": "bytes32" },
+      { "internalType": "uint8", "name": "sigV", "type": "uint8" }
+    ],
+    "name": "executeMetaTransaction",
+    "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getChainId",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getDomainSeperator",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "user", "type": "address" }],
+    "name": "getNonce",
+    "outputs": [{ "internalType": "uint256", "name": "nonce", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "role", "type": "bytes32" }],
+    "name": "getRoleAdmin",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "uint256", "name": "index", "type": "uint256" }
+    ],
+    "name": "getRoleMember",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "role", "type": "bytes32" }],
+    "name": "getRoleMemberCount",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "hasRole",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "addedValue", "type": "uint256" }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "sender", "type": "address" },
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/simulations/vip-138/simulations.ts
+++ b/simulations/vip-138/simulations.ts
@@ -1,0 +1,66 @@
+import { expect } from "chai";
+import { BigNumber } from "ethers";
+import { parseUnits } from "ethers/lib/utils";
+import { ethers } from "hardhat";
+
+import { forking, testVip } from "../../src/vip-framework";
+import { vip138 } from "../../vips/vip-138";
+import IERC20_ABI from "./abi/IERC20UpgradableAbi.json";
+
+const USDC = "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d";
+const USDT = "0x55d398326f99059ff775485246999027b3197955";
+const PECKSHIELD_RECEIVER = "0x24ee02a67c64f66ca5bcf9352f6701b46dcedff1";
+const CERTIK_RECEIVER = "0x4cf605b238e9c3c72d0faed64d12426e4a54ee12";
+const FAIRYPROOF_RECEIVER = "0x083a394785f20b244e0697c08f0e01874fde801f";
+const OZ_RECEIVER = "0x5e101FCa7a2BAB7877972bc85A1a07A2606A31B9";
+
+const PECKSHIELD_AMOUNT = parseUnits("18000", 18).add(parseUnits("6000", 18));
+const CERTIK_AMOUNT = parseUnits("19000", 18);
+const FAIRYPROOF_AMOUNT = parseUnits("20000", 18);
+const OZ_AMOUNT = parseUnits("277200", 18);
+
+forking(29726604, () => {
+  let usdc: ethers.Contract;
+  let usdt: ethers.Contract;
+  let prevBalancePeckShield: BigNumber;
+  let prevBalanceCertik: BigNumber;
+  let prevBalanceFairyproof: BigNumber;
+  let prevBalanceOZ: BigNumber;
+
+  before(async () => {
+    usdc = new ethers.Contract(USDC, IERC20_ABI, ethers.provider);
+    usdt = new ethers.Contract(USDT, IERC20_ABI, ethers.provider);
+    prevBalancePeckShield = await usdc.balanceOf(PECKSHIELD_RECEIVER);
+    prevBalanceCertik = await usdc.balanceOf(CERTIK_RECEIVER);
+    prevBalanceFairyproof = await usdc.balanceOf(FAIRYPROOF_RECEIVER);
+    prevBalanceOZ = await usdc.balanceOf(OZ_RECEIVER);
+  });
+
+  testVip("VIP-138 Payments for auditors", vip138());
+
+  describe("Post-VIP behavior", async () => {
+    it("Should increase balances of Peckshield receiver", async () => {
+      const currentBalance = await usdc.balanceOf(PECKSHIELD_RECEIVER);
+      const delta = currentBalance.sub(prevBalancePeckShield);
+      expect(delta).equals(PECKSHIELD_AMOUNT);
+    });
+
+    it("Should increase balances of Certik receiver", async () => {
+      const currentBalance = await usdt.balanceOf(CERTIK_RECEIVER);
+      const delta = currentBalance.sub(prevBalanceCertik);
+      expect(delta).equals(CERTIK_AMOUNT);
+    });
+
+    it("Should increase balances of Fairyproof receiver", async () => {
+      const currentBalance = await usdt.balanceOf(FAIRYPROOF_RECEIVER);
+      const delta = currentBalance.sub(prevBalanceFairyproof);
+      expect(delta).equals(FAIRYPROOF_AMOUNT);
+    });
+
+    it("Should increase balances of OZ receiver", async () => {
+      const currentBalance = await usdc.balanceOf(OZ_RECEIVER);
+      const delta = currentBalance.sub(prevBalanceOZ);
+      expect(delta).equals(OZ_AMOUNT);
+    });
+  });
+});

--- a/simulations/vip-138/simulations.ts
+++ b/simulations/vip-138/simulations.ts
@@ -36,7 +36,10 @@ forking(29726604, () => {
     prevBalanceOZ = await usdc.balanceOf(OZ_RECEIVER);
   });
 
-  testVip("VIP-138 Payments for auditors", vip138());
+  testVip("VIP-138 Payments for auditors", vip138(), {
+    proposer: "0xc444949e0054a23c44fc45789738bdf64aed2391",
+    supporter: "0x55A9f5374Af30E3045FB491f1da3C2E8a74d168D",
+  });
 
   describe("Post-VIP behavior", async () => {
     it("Should increase balances of Peckshield receiver", async () => {

--- a/vips/vip-138.ts
+++ b/vips/vip-138.ts
@@ -1,0 +1,61 @@
+import { parseUnits } from "ethers/lib/utils";
+
+import { ProposalType } from "../src/types";
+import { makeProposal } from "../src/utils";
+
+const TREASURY = "0xF322942f644A996A617BD29c16bd7d231d9F35E9";
+const USDC = "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d";
+const USDT = "0x55d398326f99059ff775485246999027b3197955";
+const PECKSHIELD_RECEIVER = "0x24ee02a67c64f66ca5bcf9352f6701b46dcedff1";
+const CERTIK_RECEIVER = "0x4cf605b238e9c3c72d0faed64d12426e4a54ee12";
+const FAIRYPROOF_RECEIVER = "0x083a394785f20b244e0697c08f0e01874fde801f";
+const OZ_RECEIVER = "0x5e101FCa7a2BAB7877972bc85A1a07A2606A31B9";
+
+export const vip138 = () => {
+  const meta = {
+    version: "v2",
+    title: "VIP-138 Repay BTC debt on behalf",
+    description: `
+    If passed this VIP will perform the following actions:
+      ● Transfer 18,000 USDC to Peckshield for the Diamond Comptroller audit
+      ● Transfer 6,000 USDC to Peckshield for the Oracle upgrade audit
+      ● Transfer 19,000 USDT to Certik for the retainer program
+      ● Transfer 20,000 USDT to Fairyproof for the Automatic income allocation audit
+      ● Transfer 277,200 USDC to OpenZeppelin for the security partnership`,
+    forDescription: "I agree that Venus Protocol should proceed with the payments",
+    againstDescription: "I do not think that Venus Protocol should proceed with the payments",
+    abstainDescription: "I am indifferent to whether Venus Protocol proceeds with the payments or not",
+  };
+
+  return makeProposal(
+    [
+      {
+        target: TREASURY,
+        signature: "withdrawTreasuryBEP20(address,uint256,address)",
+        params: [USDC, parseUnits("18000", 18), PECKSHIELD_RECEIVER],
+      },
+      {
+        target: TREASURY,
+        signature: "withdrawTreasuryBEP20(address,uint256,address)",
+        params: [USDC, parseUnits("6000", 18), PECKSHIELD_RECEIVER],
+      },
+      {
+        target: TREASURY,
+        signature: "withdrawTreasuryBEP20(address,uint256,address)",
+        params: [USDT, parseUnits("19000", 18), CERTIK_RECEIVER],
+      },
+      {
+        target: TREASURY,
+        signature: "withdrawTreasuryBEP20(address,uint256,address)",
+        params: [USDT, parseUnits("20000", 18), FAIRYPROOF_RECEIVER],
+      },
+      {
+        target: TREASURY,
+        signature: "withdrawTreasuryBEP20(address,uint256,address)",
+        params: [USDC, parseUnits("277200", 18), OZ_RECEIVER],
+      },
+    ],
+    meta,
+    ProposalType.REGULAR,
+  );
+};


### PR DESCRIPTION
## Description

If passed this VIP will perform the following actions:
● Transfer 18,000 USDC to Peckshield for the Diamond Comptroller audit
● Transfer 6,000 USDC to Peckshield for the Oracle upgrade audit
● Transfer 19,000 USDT to Certik for the retainer program
● Transfer 20,000 USDT to Fairyproof for the Automatic income allocation audit
● Transfer 277,200 USDC to OpenZeppelin for the security partnership`,
