### PR TITLE
[VEN-1946]: add simulations for XVS emissions reduction

### DIFF
--- a/simulations/vip-171/abi/comptroller.json
+++ b/simulations/vip-171/abi/comptroller.json
@@ -1,0 +1,1339 @@
+[
+  { "inputs": [], "payable": false, "stateMutability": "nonpayable", "type": "constructor" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": true, "internalType": "enum ComptrollerV9Storage.Action", "name": "action", "type": "uint8" },
+      { "indexed": false, "internalType": "bool", "name": "pauseState", "type": "bool" }
+    ],
+    "name": "ActionPausedMarket",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "bool", "name": "state", "type": "bool" }],
+    "name": "ActionProtocolPaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "delegate", "type": "address" },
+      { "indexed": false, "internalType": "bool", "name": "allowDelegatedBorrows", "type": "bool" }
+    ],
+    "name": "DelegateUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "venusDelta", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "venusBorrowIndex", "type": "uint256" }
+    ],
+    "name": "DistributedBorrowerVenus",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "supplier", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "venusDelta", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "venusSupplyIndex", "type": "uint256" }
+    ],
+    "name": "DistributedSupplierVenus",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }],
+    "name": "DistributedVAIVaultVenus",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "error", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "info", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "detail", "type": "uint256" }
+    ],
+    "name": "Failure",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "MarketEntered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "MarketExited",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "contract VToken", "name": "vToken", "type": "address" }],
+    "name": "MarketListed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldAccessControlAddress", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newAccessControlAddress", "type": "address" }
+    ],
+    "name": "NewAccessControl",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "newBorrowCap", "type": "uint256" }
+    ],
+    "name": "NewBorrowCap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldCloseFactorMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newCloseFactorMantissa", "type": "uint256" }
+    ],
+    "name": "NewCloseFactor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "oldCollateralFactorMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newCollateralFactorMantissa", "type": "uint256" }
+    ],
+    "name": "NewCollateralFactor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldComptrollerLens", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newComptrollerLens", "type": "address" }
+    ],
+    "name": "NewComptrollerLens",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldLiquidationIncentiveMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newLiquidationIncentiveMantissa", "type": "uint256" }
+    ],
+    "name": "NewLiquidationIncentive",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldLiquidatorContract", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newLiquidatorContract", "type": "address" }
+    ],
+    "name": "NewLiquidatorContract",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldPauseGuardian", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newPauseGuardian", "type": "address" }
+    ],
+    "name": "NewPauseGuardian",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "contract PriceOracle", "name": "oldPriceOracle", "type": "address" },
+      { "indexed": false, "internalType": "contract PriceOracle", "name": "newPriceOracle", "type": "address" }
+    ],
+    "name": "NewPriceOracle",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "newSupplyCap", "type": "uint256" }
+    ],
+    "name": "NewSupplyCap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldTreasuryAddress", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newTreasuryAddress", "type": "address" }
+    ],
+    "name": "NewTreasuryAddress",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldTreasuryGuardian", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newTreasuryGuardian", "type": "address" }
+    ],
+    "name": "NewTreasuryGuardian",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldTreasuryPercent", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newTreasuryPercent", "type": "uint256" }
+    ],
+    "name": "NewTreasuryPercent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract VAIControllerInterface",
+        "name": "oldVAIController",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract VAIControllerInterface",
+        "name": "newVAIController",
+        "type": "address"
+      }
+    ],
+    "name": "NewVAIController",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldVAIMintRate", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newVAIMintRate", "type": "uint256" }
+    ],
+    "name": "NewVAIMintRate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "vault_", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "releaseStartBlock_", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "releaseInterval_", "type": "uint256" }
+    ],
+    "name": "NewVAIVaultInfo",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldVenusVAIVaultRate", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newVenusVAIVaultRate", "type": "uint256" }
+    ],
+    "name": "NewVenusVAIVaultRate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "newSpeed", "type": "uint256" }
+    ],
+    "name": "VenusBorrowSpeedUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "recipient", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "VenusGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "newSpeed", "type": "uint256" }
+    ],
+    "name": "VenusSupplySpeedUpdated",
+    "type": "event"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "contract Unitroller", "name": "unitroller", "type": "address" }],
+    "name": "_become",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "_grantXVS",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "newAccessControlAddress", "type": "address" }],
+    "name": "_setAccessControl",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address[]", "name": "markets", "type": "address[]" },
+      { "internalType": "enum ComptrollerV9Storage.Action[]", "name": "actions", "type": "uint8[]" },
+      { "internalType": "bool", "name": "paused", "type": "bool" }
+    ],
+    "name": "_setActionsPaused",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "newCloseFactorMantissa", "type": "uint256" }],
+    "name": "_setCloseFactor",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "contract VToken", "name": "vToken", "type": "address" },
+      { "internalType": "uint256", "name": "newCollateralFactorMantissa", "type": "uint256" }
+    ],
+    "name": "_setCollateralFactor",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "contract ComptrollerLensInterface", "name": "comptrollerLens_", "type": "address" }],
+    "name": "_setComptrollerLens",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "newLiquidationIncentiveMantissa", "type": "uint256" }],
+    "name": "_setLiquidationIncentive",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "newLiquidatorContract_", "type": "address" }],
+    "name": "_setLiquidatorContract",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "contract VToken[]", "name": "vTokens", "type": "address[]" },
+      { "internalType": "uint256[]", "name": "newBorrowCaps", "type": "uint256[]" }
+    ],
+    "name": "_setMarketBorrowCaps",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "contract VToken[]", "name": "vTokens", "type": "address[]" },
+      { "internalType": "uint256[]", "name": "newSupplyCaps", "type": "uint256[]" }
+    ],
+    "name": "_setMarketSupplyCaps",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "newPauseGuardian", "type": "address" }],
+    "name": "_setPauseGuardian",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "contract PriceOracle", "name": "newOracle", "type": "address" }],
+    "name": "_setPriceOracle",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "bool", "name": "state", "type": "bool" }],
+    "name": "_setProtocolPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "newTreasuryGuardian", "type": "address" },
+      { "internalType": "address", "name": "newTreasuryAddress", "type": "address" },
+      { "internalType": "uint256", "name": "newTreasuryPercent", "type": "uint256" }
+    ],
+    "name": "_setTreasuryData",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "contract VAIControllerInterface", "name": "vaiController_", "type": "address" }],
+    "name": "_setVAIController",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "newVAIMintRate", "type": "uint256" }],
+    "name": "_setVAIMintRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vault_", "type": "address" },
+      { "internalType": "uint256", "name": "releaseStartBlock_", "type": "uint256" },
+      { "internalType": "uint256", "name": "minReleaseAmount_", "type": "uint256" }
+    ],
+    "name": "_setVAIVaultInfo",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "contract VToken[]", "name": "vTokens", "type": "address[]" },
+      { "internalType": "uint256[]", "name": "supplySpeeds", "type": "uint256[]" },
+      { "internalType": "uint256[]", "name": "borrowSpeeds", "type": "uint256[]" }
+    ],
+    "name": "_setVenusSpeeds",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "venusVAIVaultRate_", "type": "uint256" }],
+    "name": "_setVenusVAIVaultRate",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "contract VToken", "name": "vToken", "type": "address" }],
+    "name": "_supportMarket",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "name": "accountAssets",
+    "outputs": [{ "internalType": "contract VToken", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "market", "type": "address" },
+      { "internalType": "enum ComptrollerV9Storage.Action", "name": "action", "type": "uint8" }
+    ],
+    "name": "actionPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "admin",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "allMarkets",
+    "outputs": [{ "internalType": "contract VToken", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "approvedDelegates",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }
+    ],
+    "name": "borrowAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "borrowCapGuardian",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "borrowCaps",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }
+    ],
+    "name": "borrowVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "contract VToken", "name": "vToken", "type": "address" }
+    ],
+    "name": "checkMembership",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address[]", "name": "holders", "type": "address[]" },
+      { "internalType": "contract VToken[]", "name": "vTokens", "type": "address[]" },
+      { "internalType": "bool", "name": "borrowers", "type": "bool" },
+      { "internalType": "bool", "name": "suppliers", "type": "bool" },
+      { "internalType": "bool", "name": "collateral", "type": "bool" }
+    ],
+    "name": "claimVenus",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "holder", "type": "address" },
+      { "internalType": "contract VToken[]", "name": "vTokens", "type": "address[]" }
+    ],
+    "name": "claimVenus",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "holder", "type": "address" }],
+    "name": "claimVenus",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address[]", "name": "holders", "type": "address[]" },
+      { "internalType": "contract VToken[]", "name": "vTokens", "type": "address[]" },
+      { "internalType": "bool", "name": "borrowers", "type": "bool" },
+      { "internalType": "bool", "name": "suppliers", "type": "bool" }
+    ],
+    "name": "claimVenus",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "holder", "type": "address" }],
+    "name": "claimVenusAsCollateral",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "closeFactorMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "comptrollerImplementation",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "comptrollerLens",
+    "outputs": [{ "internalType": "contract ComptrollerLensInterface", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address[]", "name": "vTokens", "type": "address[]" }],
+    "name": "enterMarkets",
+    "outputs": [{ "internalType": "uint256[]", "name": "", "type": "uint256[]" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "vTokenAddress", "type": "address" }],
+    "name": "exitMarket",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "getAccountLiquidity",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getAllMarkets",
+    "outputs": [{ "internalType": "contract VToken[]", "name": "", "type": "address[]" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "getAssetsIn",
+    "outputs": [{ "internalType": "contract VToken[]", "name": "", "type": "address[]" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getBlockNumber",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "address", "name": "vTokenModify", "type": "address" },
+      { "internalType": "uint256", "name": "redeemTokens", "type": "uint256" },
+      { "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }
+    ],
+    "name": "getHypotheticalAccountLiquidity",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getXVSAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getXVSVTokenAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "isComptroller",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vTokenBorrowed", "type": "address" },
+      { "internalType": "address", "name": "vTokenCollateral", "type": "address" },
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "liquidateBorrowAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vTokenBorrowed", "type": "address" },
+      { "internalType": "address", "name": "vTokenCollateral", "type": "address" },
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "actualRepayAmount", "type": "uint256" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "liquidateBorrowVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "vTokenBorrowed", "type": "address" },
+      { "internalType": "address", "name": "vTokenCollateral", "type": "address" },
+      { "internalType": "uint256", "name": "actualRepayAmount", "type": "uint256" }
+    ],
+    "name": "liquidateCalculateSeizeTokens",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "vTokenCollateral", "type": "address" },
+      { "internalType": "uint256", "name": "actualRepayAmount", "type": "uint256" }
+    ],
+    "name": "liquidateVAICalculateSeizeTokens",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "liquidationIncentiveMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "liquidatorContract",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "markets",
+    "outputs": [
+      { "internalType": "bool", "name": "isListed", "type": "bool" },
+      { "internalType": "uint256", "name": "collateralFactorMantissa", "type": "uint256" },
+      { "internalType": "bool", "name": "isVenus", "type": "bool" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "maxAssets",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "minReleaseAmount",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "minter", "type": "address" },
+      { "internalType": "uint256", "name": "mintAmount", "type": "uint256" }
+    ],
+    "name": "mintAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "mintVAIGuardianPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "minter", "type": "address" },
+      { "internalType": "uint256", "name": "actualMintAmount", "type": "uint256" },
+      { "internalType": "uint256", "name": "mintTokens", "type": "uint256" }
+    ],
+    "name": "mintVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "mintedVAIs",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "oracle",
+    "outputs": [{ "internalType": "contract PriceOracle", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pauseGuardian",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pendingAdmin",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pendingComptrollerImplementation",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "protocolPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "redeemer", "type": "address" },
+      { "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }
+    ],
+    "name": "redeemAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "redeemer", "type": "address" },
+      { "internalType": "uint256", "name": "redeemAmount", "type": "uint256" },
+      { "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }
+    ],
+    "name": "redeemVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "releaseStartBlock",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "releaseToVault",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "payer", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "repayBorrowAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "payer", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "actualRepayAmount", "type": "uint256" },
+      { "internalType": "uint256", "name": "borrowerIndex", "type": "uint256" }
+    ],
+    "name": "repayBorrowVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "repayVAIGuardianPaused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vTokenCollateral", "type": "address" },
+      { "internalType": "address", "name": "vTokenBorrowed", "type": "address" },
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "seizeAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vTokenCollateral", "type": "address" },
+      { "internalType": "address", "name": "vTokenBorrowed", "type": "address" },
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "seizeVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "setMintedVAIOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "supplyCaps",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "src", "type": "address" },
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "transferTokens", "type": "uint256" }
+    ],
+    "name": "transferAllowed",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "src", "type": "address" },
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "transferTokens", "type": "uint256" }
+    ],
+    "name": "transferVerify",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "treasuryAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "treasuryGuardian",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "treasuryPercent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "delegate", "type": "address" },
+      { "internalType": "bool", "name": "allowBorrows", "type": "bool" }
+    ],
+    "name": "updateDelegate",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "vaiController",
+    "outputs": [{ "internalType": "contract VAIControllerInterface", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "vaiMintRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "vaiVaultAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "venusAccrued",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "venusBorrowSpeeds",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "venusBorrowState",
+    "outputs": [
+      { "internalType": "uint224", "name": "index", "type": "uint224" },
+      { "internalType": "uint32", "name": "block", "type": "uint32" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "venusBorrowerIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "venusInitialIndex",
+    "outputs": [{ "internalType": "uint224", "name": "", "type": "uint224" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "venusRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "venusSpeeds",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "venusSupplierIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "venusSupplySpeeds",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "venusSupplyState",
+    "outputs": [
+      { "internalType": "uint224", "name": "index", "type": "uint224" },
+      { "internalType": "uint32", "name": "block", "type": "uint32" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "venusVAIVaultRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/simulations/vip-171/simulations.ts
+++ b/simulations/vip-171/simulations.ts
@@ -1,0 +1,240 @@
+import { TransactionResponse } from "@ethersproject/providers";
+import { expect } from "chai";
+import { BigNumber, Contract } from "ethers";
+import { ethers } from "hardhat";
+
+import { expectEvents } from "../../src/utils";
+import { forking, testVip } from "../../src/vip-framework";
+import { SpeedRecord, vip171 } from "../../vips/vip-171";
+import COMPTROLLER_ABI from "./abi/comptroller.json";
+
+const COMPTROLLER = "0xfD36E2c2a6789Db23113685031d7F16329158384";
+
+const OLD_SPEEDS: SpeedRecord[] = [
+  {
+    market: "0xecA88125a5ADbe82614ffC12D0DB554E2e2867C8",
+    symbol: "vUSDC",
+    supplySideSpeed: "2712673611111111",
+    borrowSideSpeed: "2712673611111111",
+  },
+  {
+    market: "0xfD5840Cd36d94D7229439859C0112a4185BC0255",
+    symbol: "vUSDT",
+    supplySideSpeed: "2712673611111111",
+    borrowSideSpeed: "2712673611111111",
+  },
+  {
+    market: "0x95c78222B3D6e262426483D42CfA53685A67Ab9D",
+    symbol: "vBUSD",
+    supplySideSpeed: "0",
+    borrowSideSpeed: "0",
+  },
+  {
+    market: "0x2fF3d0F6990a40261c66E1ff2017aCBc282EB6d0",
+    symbol: "vSXP",
+    supplySideSpeed: "0",
+    borrowSideSpeed: "0",
+  },
+  {
+    market: "0x151B1e2635A717bcDc836ECd6FbB62B674FE3E1D",
+    symbol: "vXVS",
+    supplySideSpeed: "0",
+    borrowSideSpeed: "0",
+  },
+  {
+    market: "0xA07c5b74C9B40447a954e1466938b865b6BBea36",
+    symbol: "vBNB",
+    supplySideSpeed: "6510416666666666",
+    borrowSideSpeed: "6510416666666666",
+  },
+  {
+    market: "0x882C173bC7Ff3b7786CA16dfeD3DFFfb9Ee7847B",
+    symbol: "vBTC",
+    supplySideSpeed: "6510416666666666",
+    borrowSideSpeed: "6510416666666666",
+  },
+  {
+    market: "0xf508fCD89b8bd15579dc79A6827cB4686A3592c8",
+    symbol: "vETH",
+    supplySideSpeed: "3255208333333333",
+    borrowSideSpeed: "3255208333333333",
+  },
+  {
+    market: "0x57A5297F2cB2c0AaC9D554660acd6D385Ab50c6B",
+    symbol: "vLTC",
+    supplySideSpeed: "198871527777778",
+    borrowSideSpeed: "198871527777778",
+  },
+  {
+    market: "0xB248a295732e0225acd3337607cc01068e3b9c10",
+    symbol: "vXRP",
+    supplySideSpeed: "198871527777778",
+    borrowSideSpeed: "198871527777778",
+  },
+  {
+    market: "0x5F0388EBc2B94FA8E123F404b79cCF5f40b29176",
+    symbol: "vBCH",
+    supplySideSpeed: "108506944444444",
+    borrowSideSpeed: "108506944444444",
+  },
+  {
+    market: "0x1610bc33319e9398de5f57B33a5b184c806aD217",
+    symbol: "vDOT",
+    supplySideSpeed: "318142361111111",
+    borrowSideSpeed: "318142361111111",
+  },
+  {
+    market: "0x650b940a1033B8A1b1873f78730FcFC73ec11f1f",
+    symbol: "vLINK",
+    supplySideSpeed: "198871527777778",
+    borrowSideSpeed: "198871527777778",
+  },
+  {
+    market: "0x334b3eCB4DCa3593BCCC3c7EBD1A1C1d1780FBF1",
+    symbol: "vDAI",
+    supplySideSpeed: "325520833333333",
+    borrowSideSpeed: "325520833333333",
+  },
+  {
+    market: "0xf91d58b5aE142DAcC749f58A49FCBac340Cb0343",
+    symbol: "vFIL",
+    supplySideSpeed: "108506944444444",
+    borrowSideSpeed: "108506944444444",
+  },
+  {
+    market: "0x972207A639CC1B374B893cc33Fa251b55CEB7c07",
+    symbol: "vBETH",
+    supplySideSpeed: "0",
+    borrowSideSpeed: "0",
+  },
+  {
+    market: "0xeBD0070237a0713E8D94fEf1B728d3d993d290ef",
+    symbol: "vCAN",
+    supplySideSpeed: "0",
+    borrowSideSpeed: "0",
+  },
+  {
+    market: "0x9A0AF7FDb2065Ce470D72664DE73cAE409dA28Ec",
+    symbol: "vADA",
+    supplySideSpeed: "325520833333333",
+    borrowSideSpeed: "325520833333333",
+  },
+  {
+    market: "0xec3422Ef92B2fb59e84c8B02Ba73F1fE84Ed8D71",
+    symbol: "vDOGE",
+    supplySideSpeed: "108506944444444",
+    borrowSideSpeed: "108506944444444",
+  },
+  {
+    market: "0x5c9476FcD6a4F9a3654139721c949c2233bBbBc8",
+    symbol: "vMATIC",
+    supplySideSpeed: "217013888888889",
+    borrowSideSpeed: "217013888888889",
+  },
+  {
+    market: "0x86aC3974e2BD0d60825230fa6F355fF11409df5c",
+    symbol: "vCAKE",
+    supplySideSpeed: "217013888888889",
+    borrowSideSpeed: "217013888888889",
+  },
+  {
+    market: "0x26DA28954763B92139ED49283625ceCAf52C6f94",
+    symbol: "vAAVE",
+    supplySideSpeed: "108506944444444",
+    borrowSideSpeed: "108506944444444",
+  },
+  {
+    market: "0x08CEB3F4a7ed3500cA0982bcd0FC7816688084c3",
+    symbol: "vTUSDOLD",
+    supplySideSpeed: "0",
+    borrowSideSpeed: "0",
+  },
+  {
+    market: "0x61eDcFe8Dd6bA3c891CB9bEc2dc7657B3B422E93",
+    symbol: "vTRXOLD",
+    supplySideSpeed: "0",
+    borrowSideSpeed: "0",
+  },
+  {
+    market: "0x78366446547D062f45b4C0f320cDaa6d710D87bb",
+    symbol: "vUST",
+    supplySideSpeed: "0",
+    borrowSideSpeed: "0",
+  },
+  {
+    market: "0xb91A659E88B51474767CD97EF3196A3e7cEDD2c8",
+    symbol: "vLUNA",
+    supplySideSpeed: "0",
+    borrowSideSpeed: "0",
+  },
+  {
+    market: "0xC5D3466aA484B040eE977073fcF337f2c00071c1",
+    symbol: "vTRX",
+    supplySideSpeed: "217013888888889",
+    borrowSideSpeed: "217013888888889",
+  },
+  {
+    market: "0x6CFdEc747f37DAf3b87a35a1D9c8AD3063A1A8A0",
+    symbol: "vWBETH",
+    supplySideSpeed: "596440972222220",
+    borrowSideSpeed: "596440972222220",
+  },
+  {
+    market: "0xBf762cd5991cA1DCdDaC9ae5C638F5B5Dc3Bee6E",
+    symbol: "vTUSD",
+    supplySideSpeed: "217013888888889",
+    borrowSideSpeed: "217013888888889",
+  },
+];
+
+forking(31758000, () => {
+  let comptroller: Contract;
+
+  before(async () => {
+    comptroller = await ethers.getContractAt(COMPTROLLER_ABI, COMPTROLLER);
+  });
+
+  describe("Simulation correctness & pre-VIP state", () => {
+    it("tests all markets", async () => {
+      const markets = await comptroller.getAllMarkets();
+      expect(markets).to.deep.equal(OLD_SPEEDS.map(speed => speed.market));
+    });
+
+    for (const speedRecord of OLD_SPEEDS) {
+      it(`has the expected supply-side distribution speed for ${speedRecord.symbol}`, async () => {
+        const supplySpeed = await comptroller.venusSupplySpeeds(speedRecord.market);
+        expect(supplySpeed).to.equal(speedRecord.supplySideSpeed);
+      });
+
+      it(`has the expected borrow-side distribution speed for ${speedRecord.symbol}`, async () => {
+        const borrowSpeed = await comptroller.venusBorrowSpeeds(speedRecord.market);
+        expect(borrowSpeed).to.equal(speedRecord.borrowSideSpeed);
+      });
+    }
+  });
+
+  testVip("Decrease XVS distribution speeds", vip171(), {
+    callbackAfterExecution: async (txResponse: TransactionResponse) => {
+      await expectEvents(
+        txResponse,
+        [COMPTROLLER_ABI],
+        ["VenusSupplySpeedUpdated", "VenusBorrowSpeedUpdated"],
+        [20, 20],
+      );
+    },
+  });
+
+  describe("Post-VIP state", () => {
+    for (const oldSpeed of OLD_SPEEDS) {
+      it(`reduces supply-side distribution speed for ${oldSpeed.symbol} by 75%`, async () => {
+        const supplySpeed = await comptroller.venusSupplySpeeds(oldSpeed.market);
+        expect(supplySpeed).to.equal(BigNumber.from(oldSpeed.supplySideSpeed).div(4));
+      });
+
+      it(`reduces borrow-side distribution speed for ${oldSpeed.symbol} by 75%`, async () => {
+        const borrowSpeed = await comptroller.venusBorrowSpeeds(oldSpeed.market);
+        expect(borrowSpeed).to.equal(BigNumber.from(oldSpeed.borrowSideSpeed).div(4));
+      });
+    }
+  });
+});

--- a/vips/vip-171.ts
+++ b/vips/vip-171.ts
@@ -1,0 +1,161 @@
+import { ProposalType } from "../src/types";
+import { makeProposal } from "../src/utils";
+
+const COMPTROLLER = "0xfD36E2c2a6789Db23113685031d7F16329158384";
+
+export interface SpeedRecord {
+  market: string;
+  symbol: string;
+  supplySideSpeed: string;
+  borrowSideSpeed: string;
+}
+
+const newSpeeds: SpeedRecord[] = [
+  {
+    market: "0xecA88125a5ADbe82614ffC12D0DB554E2e2867C8",
+    symbol: "vUSDC",
+    supplySideSpeed: "678168402777777",
+    borrowSideSpeed: "678168402777777",
+  },
+  {
+    market: "0xfD5840Cd36d94D7229439859C0112a4185BC0255",
+    symbol: "vUSDT",
+    supplySideSpeed: "678168402777777",
+    borrowSideSpeed: "678168402777777",
+  },
+  {
+    market: "0xA07c5b74C9B40447a954e1466938b865b6BBea36",
+    symbol: "vBNB",
+    supplySideSpeed: "1627604166666666",
+    borrowSideSpeed: "1627604166666666",
+  },
+  {
+    market: "0x882C173bC7Ff3b7786CA16dfeD3DFFfb9Ee7847B",
+    symbol: "vBTC",
+    supplySideSpeed: "1627604166666666",
+    borrowSideSpeed: "1627604166666666",
+  },
+  {
+    market: "0xf508fCD89b8bd15579dc79A6827cB4686A3592c8",
+    symbol: "vETH",
+    supplySideSpeed: "813802083333333",
+    borrowSideSpeed: "813802083333333",
+  },
+  {
+    market: "0x57A5297F2cB2c0AaC9D554660acd6D385Ab50c6B",
+    symbol: "vLTC",
+    supplySideSpeed: "49717881944444",
+    borrowSideSpeed: "49717881944444",
+  },
+  {
+    market: "0xB248a295732e0225acd3337607cc01068e3b9c10",
+    symbol: "vXRP",
+    supplySideSpeed: "49717881944444",
+    borrowSideSpeed: "49717881944444",
+  },
+  {
+    market: "0x5F0388EBc2B94FA8E123F404b79cCF5f40b29176",
+    symbol: "vBCH",
+    supplySideSpeed: "27126736111111",
+    borrowSideSpeed: "27126736111111",
+  },
+  {
+    market: "0x1610bc33319e9398de5f57B33a5b184c806aD217",
+    symbol: "vDOT",
+    supplySideSpeed: "79535590277777",
+    borrowSideSpeed: "79535590277777",
+  },
+  {
+    market: "0x650b940a1033B8A1b1873f78730FcFC73ec11f1f",
+    symbol: "vLINK",
+    supplySideSpeed: "49717881944444",
+    borrowSideSpeed: "49717881944444",
+  },
+  {
+    market: "0x334b3eCB4DCa3593BCCC3c7EBD1A1C1d1780FBF1",
+    symbol: "vDAI",
+    supplySideSpeed: "81380208333333",
+    borrowSideSpeed: "81380208333333",
+  },
+  {
+    market: "0xf91d58b5aE142DAcC749f58A49FCBac340Cb0343",
+    symbol: "vFIL",
+    supplySideSpeed: "27126736111111",
+    borrowSideSpeed: "27126736111111",
+  },
+  {
+    market: "0x9A0AF7FDb2065Ce470D72664DE73cAE409dA28Ec",
+    symbol: "vADA",
+    supplySideSpeed: "81380208333333",
+    borrowSideSpeed: "81380208333333",
+  },
+  {
+    market: "0xec3422Ef92B2fb59e84c8B02Ba73F1fE84Ed8D71",
+    symbol: "vDOGE",
+    supplySideSpeed: "27126736111111",
+    borrowSideSpeed: "27126736111111",
+  },
+  {
+    market: "0x5c9476FcD6a4F9a3654139721c949c2233bBbBc8",
+    symbol: "vMATIC",
+    supplySideSpeed: "54253472222222",
+    borrowSideSpeed: "54253472222222",
+  },
+  {
+    market: "0x86aC3974e2BD0d60825230fa6F355fF11409df5c",
+    symbol: "vCAKE",
+    supplySideSpeed: "54253472222222",
+    borrowSideSpeed: "54253472222222",
+  },
+  {
+    market: "0x26DA28954763B92139ED49283625ceCAf52C6f94",
+    symbol: "vAAVE",
+    supplySideSpeed: "27126736111111",
+    borrowSideSpeed: "27126736111111",
+  },
+  {
+    market: "0xC5D3466aA484B040eE977073fcF337f2c00071c1",
+    symbol: "vTRX",
+    supplySideSpeed: "54253472222222",
+    borrowSideSpeed: "54253472222222",
+  },
+  {
+    market: "0x6CFdEc747f37DAf3b87a35a1D9c8AD3063A1A8A0",
+    symbol: "vWBETH",
+    supplySideSpeed: "149110243055555",
+    borrowSideSpeed: "149110243055555",
+  },
+  {
+    market: "0xBf762cd5991cA1DCdDaC9ae5C638F5B5Dc3Bee6E",
+    symbol: "vTUSD",
+    supplySideSpeed: "54253472222222",
+    borrowSideSpeed: "54253472222222",
+  },
+];
+
+export const vip171 = () => {
+  const meta = {
+    version: "v2",
+    title: "Reduce XVS emissions by 75%",
+    description: `.`,
+    forDescription: "I agree that Venus Protocol should reduce XVS emissions by 75%",
+    againstDescription: "I do not think that Venus Protocol should reduce XVS emissions by 75%",
+    abstainDescription: "I am indifferent to whether Venus Protocol reduces XVS emissions by 75% or not",
+  };
+
+  return makeProposal(
+    [
+      {
+        target: COMPTROLLER,
+        signature: "_setVenusSpeeds(address[],uint256[],uint256[])",
+        params: [
+          newSpeeds.map(s => s.market),
+          newSpeeds.map(s => s.supplySideSpeed),
+          newSpeeds.map(s => s.borrowSideSpeed),
+        ],
+      },
+    ],
+    meta,
+    ProposalType.REGULAR,
+  );
+};

--- a/vips/vip-171.ts
+++ b/vips/vip-171.ts
@@ -136,11 +136,35 @@ const newSpeeds: SpeedRecord[] = [
 export const vip171 = () => {
   const meta = {
     version: "v2",
-    title: "Reduce XVS emissions by 75%",
-    description: `.`,
-    forDescription: "I agree that Venus Protocol should reduce XVS emissions by 75%",
-    againstDescription: "I do not think that Venus Protocol should reduce XVS emissions by 75%",
-    abstainDescription: "I am indifferent to whether Venus Protocol reduces XVS emissions by 75% or not",
+    title: "VIP-171 XVS Emission Reduction",
+    description: `#### Summary
+
+After the successful passing of the [snapshot vote](https://snapshot.org/#/venus-xvs.eth/proposal/0x031cec704a0b3cf3163fa03b8f04bca2b3d7299f0b53962d595a252952a1cc9a) to reduce XVS emissions earlier this week, this VIP is now being issued for the changes to be implemented and take effect immediately after its execution. If approved by the majority of XVS Holders, this VIP will reduce the amount of daily XVS emission on Venus Core pool markets.
+
+The current emission on the core pool markets is 1,449.55 XVS/day, and after the change the daily emission of XVS in the markets will be 362.38625 XVS/day.
+
+#### Reasoning
+
+With the upcoming launch of the Venus Prime program and current market trends, this proposal aims to further reduce XVS emissions on Venus Core markets by 75%. The new organic reward system for this program will help offset the effects. The goal is to keep reducing token inflation and with it, support protocol growth and reinvestment.
+
+#### Venus Prime Program Overview
+
+Venus Prime stands as a strategic shift in the Venus Protocol’s reward mechanism. Diverging from the traditional token emission method, Venus Prime is engineered to distribute rewards based on protocol performance. This organic reward system is expected to drive user engagement and loyalty, while simultaneously reducing dependency on regular emissions which can contribute to token inflation and associated market pressures.
+
+#### Mitigating Impact of Emission Reduction with Venus Prime
+
+Organic Rewards: Venus Prime eliminates the need for frequent token emissions, thus reducing the inflationary pressures on the XVS token.
+
+Incentivizing Long-Term Engagement: With Venus Prime, users are not just rewarded for mere participation but for their loyalty and consistent engagement with the protocol. This ensures that while emissions are cut, user retention and attraction remain high.
+
+The shift towards a sustainable rewards model ensures that the Venus Protocol remains financially robust, aligning the interests of users with the protocol’s long-term viability.
+
+#### Conclusion
+
+The Venus Prime program offers a sustainable and innovative solution to the challenges posed by regular token emissions. By harnessing the protocol’s own revenues for user rewards and fostering an environment of long-term engagement, Venus Prime ensures that the proposed emission reductions not only maintain but enhance the protocol’s market position and user appeal.`,
+    forDescription: "I agree, Venus should reduce daily XVS emissions",
+    againstDescription: "I disagree, Venus should not reduce daily XVS emissions",
+    abstainDescription: "I am indifferent to whether Venus proceeds or not",
   };
 
   return makeProposal(


### PR DESCRIPTION
This VIP reduces XVS emissions by 75% for all markets in the core pool (except those where XVS rewards are disabled). VAI vault emission rate stays unchanged.