### PR TITLE
[VEN-2325]: swap 0.3 BBTC for WBTC

### DIFF
--- a/multisig/proposals/vip-002/vip-002-ethereum-bootstrap-liquidity.ts
+++ b/multisig/proposals/vip-002/vip-002-ethereum-bootstrap-liquidity.ts
@@ -1,0 +1,17 @@
+import { makeProposal } from "../../../src/utils";
+
+const VTREASURY = "0xFD9B071168bC27DBE16406eC3Aba050Ce8Eb22FA";
+const COMMUNITY_WALLET = "0xc444949e0054A23c44Fc45789738bdF64aed2391";
+const BBTC = "0x9BE89D2a4cd102D8Fecc6BF9dA793be995C22541";
+
+const BBTC_AMOUNT = "30000000";
+
+export const vip002 = () => {
+  return makeProposal([
+    {
+      target: VTREASURY,
+      signature: "withdrawTreasuryToken(address,uint256,address)",
+      params: [BBTC, BBTC_AMOUNT, COMMUNITY_WALLET],
+    },
+  ]);
+};

--- a/multisig/proposals/vip-002/vip-002-ethereum-bootstrap-liquidity.ts
+++ b/multisig/proposals/vip-002/vip-002-ethereum-bootstrap-liquidity.ts
@@ -1,17 +1,46 @@
+import { hours } from "@nomicfoundation/hardhat-network-helpers/dist/src/helpers/time/duration";
+import { concat, hexlify, parseUnits } from "ethers/lib/utils";
+
+import { NETWORK_ADDRESSES } from "../../../src/networkAddresses";
 import { makeProposal } from "../../../src/utils";
 
-const VTREASURY = "0xFD9B071168bC27DBE16406eC3Aba050Ce8Eb22FA";
-const COMMUNITY_WALLET = "0xc444949e0054A23c44Fc45789738bdF64aed2391";
-const BBTC = "0x9BE89D2a4cd102D8Fecc6BF9dA793be995C22541";
+// Make sure to update the deadline before submitting the transaction
+const NOW = 1705566017;
+const DEADLINE = NOW + hours(4);
 
-const BBTC_AMOUNT = "30000000";
+const VTREASURY = "0xFD9B071168bC27DBE16406eC3Aba050Ce8Eb22FA";
+const UNI_V3_ROUTER = "0xE592427A0AEce92De3Edee1F18E0157C05861564";
+const BBTC = "0x9BE89D2a4cd102D8Fecc6BF9dA793be995C22541";
+const WBTC = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599";
+const NORMAL_TIMELOCK = NETWORK_ADDRESSES.ethereum.NORMAL_TIMELOCK;
+
+const BBTC_AMOUNT = parseUnits("0.3", 8);
+const MIN_WBTC_AMOUNT = parseUnits("0.295029", 8);
+
+const FEE_HEX = "0x000bb8";
+const PATH = hexlify(concat([BBTC, FEE_HEX, WBTC]));
 
 export const vip002 = () => {
   return makeProposal([
     {
       target: VTREASURY,
       signature: "withdrawTreasuryToken(address,uint256,address)",
-      params: [BBTC, BBTC_AMOUNT, COMMUNITY_WALLET],
+      params: [BBTC, BBTC_AMOUNT, NORMAL_TIMELOCK],
+    },
+    {
+      target: BBTC,
+      signature: "approve(address,uint256)",
+      params: [UNI_V3_ROUTER, BBTC_AMOUNT],
+    },
+    {
+      target: UNI_V3_ROUTER,
+      signature: "exactInput((bytes,address,uint256,uint256,uint256))",
+      params: [[PATH, VTREASURY, DEADLINE, BBTC_AMOUNT, MIN_WBTC_AMOUNT]],
+    },
+    {
+      target: BBTC,
+      signature: "approve(address,uint256)",
+      params: [UNI_V3_ROUTER, 0],
     },
   ]);
 };

--- a/multisig/simulations/vip-002/vip-002-ethereum-bootstrap-liquidity/abis/ERC20.json
+++ b/multisig/simulations/vip-002/vip-002-ethereum-bootstrap-liquidity/abis/ERC20.json
@@ -1,0 +1,295 @@
+[
+  {
+    "inputs": [
+      { "internalType": "string", "name": "name_", "type": "string" },
+      { "internalType": "string", "name": "symbol_", "type": "string" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "spender", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "userAddress", "type": "address" },
+      { "indexed": false, "internalType": "address payable", "name": "relayerAddress", "type": "address" },
+      { "indexed": false, "internalType": "bytes", "name": "functionSignature", "type": "bytes" }
+    ],
+    "name": "MetaTransactionExecuted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "indexed": true, "internalType": "bytes32", "name": "previousAdminRole", "type": "bytes32" },
+      { "indexed": true, "internalType": "bytes32", "name": "newAdminRole", "type": "bytes32" }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "account", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "sender", "type": "address" }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "account", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "sender", "type": "address" }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ERC712_VERSION",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PREDICATE_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "subtractedValue", "type": "uint256" }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "userAddress", "type": "address" },
+      { "internalType": "bytes", "name": "functionSignature", "type": "bytes" },
+      { "internalType": "bytes32", "name": "sigR", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "sigS", "type": "bytes32" },
+      { "internalType": "uint8", "name": "sigV", "type": "uint8" }
+    ],
+    "name": "executeMetaTransaction",
+    "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getChainId",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getDomainSeperator",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "user", "type": "address" }],
+    "name": "getNonce",
+    "outputs": [{ "internalType": "uint256", "name": "nonce", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "role", "type": "bytes32" }],
+    "name": "getRoleAdmin",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "uint256", "name": "index", "type": "uint256" }
+    ],
+    "name": "getRoleMember",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "role", "type": "bytes32" }],
+    "name": "getRoleMemberCount",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "hasRole",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "addedValue", "type": "uint256" }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "sender", "type": "address" },
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/multisig/simulations/vip-002/vip-002-ethereum-bootstrap-liquidity/simulations.ts
+++ b/multisig/simulations/vip-002/vip-002-ethereum-bootstrap-liquidity/simulations.ts
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+
+import { forking, pretendExecutingVip } from "../../../../src/vip-framework";
+import { vip002 } from "../../../proposals/vip-002/vip-002-ethereum-bootstrap-liquidity";
+import ERC20_ABI from "./abis/ERC20.json";
+
+const VTREASURY = "0xFD9B071168bC27DBE16406eC3Aba050Ce8Eb22FA";
+const COMMUNITY_WALLET = "0xc444949e0054A23c44Fc45789738bdF64aed2391";
+const BBTC = "0x9BE89D2a4cd102D8Fecc6BF9dA793be995C22541";
+
+const BBTC_AMOUNT = "30000000";
+
+forking(19020650, () => {
+  let bbtc: ethers.Contract;
+  let oldBBTCBal: BigNumber;
+  let oldBBTCBalTreasury: BigNumber;
+
+  before(async () => {
+    bbtc = new ethers.Contract(BBTC, ERC20_ABI, ethers.provider);
+    oldBBTCBal = await bbtc.balanceOf(COMMUNITY_WALLET);
+    oldBBTCBalTreasury = await bbtc.balanceOf(VTREASURY);
+  });
+
+  describe("Post-VIP behavior", async () => {
+    before(async () => {
+      await pretendExecutingVip(vip002());
+    });
+
+    it("Should transfer BBTC", async () => {
+      const currBBTCBal = await bbtc.balanceOf(COMMUNITY_WALLET);
+      expect(currBBTCBal.sub(oldBBTCBal)).equals(BBTC_AMOUNT);
+      const currBBTCBalTreasury = await bbtc.balanceOf(VTREASURY);
+      expect(currBBTCBalTreasury.add(BBTC_AMOUNT)).equals(oldBBTCBalTreasury);
+    });
+  });
+});

--- a/multisig/simulations/vip-002/vip-002-ethereum-bootstrap-liquidity/simulations.ts
+++ b/multisig/simulations/vip-002/vip-002-ethereum-bootstrap-liquidity/simulations.ts
@@ -1,25 +1,33 @@
 import { expect } from "chai";
+import { BigNumber, Contract } from "ethers";
+import { parseUnits } from "ethers/lib/utils";
 import { ethers } from "hardhat";
 
+import { NETWORK_ADDRESSES } from "../../../../src/networkAddresses";
 import { forking, pretendExecutingVip } from "../../../../src/vip-framework";
 import { vip002 } from "../../../proposals/vip-002/vip-002-ethereum-bootstrap-liquidity";
 import ERC20_ABI from "./abis/ERC20.json";
 
 const VTREASURY = "0xFD9B071168bC27DBE16406eC3Aba050Ce8Eb22FA";
-const COMMUNITY_WALLET = "0xc444949e0054A23c44Fc45789738bdF64aed2391";
+const NORMAL_TIMELOCK = NETWORK_ADDRESSES.ethereum.NORMAL_TIMELOCK;
+const UNI_V3_ROUTER = "0xE592427A0AEce92De3Edee1F18E0157C05861564";
 const BBTC = "0x9BE89D2a4cd102D8Fecc6BF9dA793be995C22541";
+const WBTC = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599";
 
-const BBTC_AMOUNT = "30000000";
+const BBTC_AMOUNT = parseUnits("0.3", 8);
+const WBTC_AMOUNT = parseUnits("0.29818818", 8);
 
-forking(19020650, () => {
-  let bbtc: ethers.Contract;
-  let oldBBTCBal: BigNumber;
-  let oldBBTCBalTreasury: BigNumber;
+forking(19032429, () => {
+  let wbtc: Contract;
+  let bbtc: Contract;
+  let oldWBTCBalance: BigNumber;
+  let oldBBTCBalance: BigNumber;
 
   before(async () => {
+    wbtc = new ethers.Contract(WBTC, ERC20_ABI, ethers.provider);
     bbtc = new ethers.Contract(BBTC, ERC20_ABI, ethers.provider);
-    oldBBTCBal = await bbtc.balanceOf(COMMUNITY_WALLET);
-    oldBBTCBalTreasury = await bbtc.balanceOf(VTREASURY);
+    oldWBTCBalance = await wbtc.balanceOf(VTREASURY);
+    oldBBTCBalance = await bbtc.balanceOf(VTREASURY);
   });
 
   describe("Post-VIP behavior", async () => {
@@ -27,11 +35,26 @@ forking(19020650, () => {
       await pretendExecutingVip(vip002());
     });
 
-    it("Should transfer BBTC", async () => {
-      const currBBTCBal = await bbtc.balanceOf(COMMUNITY_WALLET);
-      expect(currBBTCBal.sub(oldBBTCBal)).equals(BBTC_AMOUNT);
-      const currBBTCBalTreasury = await bbtc.balanceOf(VTREASURY);
-      expect(currBBTCBalTreasury.add(BBTC_AMOUNT)).equals(oldBBTCBalTreasury);
+    it("should transfer BBTC out of treasury", async () => {
+      const currentBBTCBalance = await bbtc.balanceOf(VTREASURY);
+      expect(oldBBTCBalance.sub(currentBBTCBalance)).equals(BBTC_AMOUNT);
+    });
+
+    it("should transfer WBTC to treasury", async () => {
+      const currentWBTCBalance = await wbtc.balanceOf(VTREASURY);
+      expect(currentWBTCBalance.sub(oldWBTCBalance)).equals(WBTC_AMOUNT);
+    });
+
+    it("should not keep BBTC in the multisig", async () => {
+      expect(await bbtc.balanceOf(NORMAL_TIMELOCK)).equals(0);
+    });
+
+    it("should not keep WBTC in the multisig", async () => {
+      expect(await wbtc.balanceOf(NORMAL_TIMELOCK)).equals(0);
+    });
+
+    it("should not have any remaining approvals", async () => {
+      expect(await bbtc.allowance(NORMAL_TIMELOCK, UNI_V3_ROUTER)).equals(0);
     });
   });
 });


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->

Resolves VEN-2320

We need WBTC tokens, not BBTC. We'll swap the BBTC tokens for WBTC using Uniswap, and send them to the VTreasuryV8 contract

Related to https://github.com/VenusProtocol/vips/pull/162
