### PR TITLE
feat: add support for arbitrary vip paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ coverage.json
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Generated files
+venusApp.json
+gnosisTXBuilder.json

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ yarn install
 
 ```
 
+### Repo structure
+
+The simulations and create commands require the function creating the VIP to be the default export.
+
 ### Run Simulations
 
 ```

--- a/scripts/createProposal.ts
+++ b/scripts/createProposal.ts
@@ -12,13 +12,15 @@ const readline = require("readline-sync");
 
 const safeAddress = "0x12341234123412341234123412341232412341234";
 
-let vipNumber: string;
+let vipPath: string;
 let governorAddress: string | null;
 let transactionType: string;
 
 function processInputs(): Promise<void> {
   return new Promise(resolve => {
-    vipNumber = readline.question("Number of the VIP to propose (if using gnosisTXBuilder press enter to skip ) => ");
+    vipPath = readline.question(
+      "Path relative to ./vips directory to the VIP to propose e.g. vip-244/bscmainnet (if using gnosisTXBuilder press enter to skip ) => ",
+    );
     transactionType = readline.question("Type of the proposal txBuilder/venusApp/bsc/gnosisTXBuilder => ");
     governorAddress = readline.question("Address of the governance contract (optional, press enter to skip) => ");
     if (!governorAddress) {
@@ -46,7 +48,7 @@ const processJson = async (data: JsonObject) => {
 };
 
 const processTxBuilder = async () => {
-  const result = await proposeVIP(vipNumber, governorAddress);
+  const result = await proposeVIP(vipPath, governorAddress);
   const transactions = [
     {
       to: result.target,
@@ -71,7 +73,7 @@ const processGnosisTxBuilder = async () => {
 };
 
 const processVenusAppProposal = async () => {
-  const proposal = await loadProposal(vipNumber);
+  const proposal = await loadProposal(vipPath);
   const validate = new Ajv().compile(proposalSchema);
   const isValid = validate(proposal);
 
@@ -83,7 +85,7 @@ const processVenusAppProposal = async () => {
 };
 
 const processBscProposal = async () => {
-  const proposal = await loadProposal(vipNumber);
+  const proposal = await loadProposal(vipPath);
   const data = {
     targets: proposal.targets,
     signatures: proposal.signatures,

--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -4,14 +4,13 @@ import { getCalldatas } from "./utils";
 
 const DEFAULT_GOVERNOR_PROXY = "0x2d56dC077072B53571b8252008C60e945108c75a";
 
-export const loadProposal = async (num: string) => {
-  const x = await import(`../vips/vip-${num}.ts`);
-  num = num.replace("-testnet", "Testnet");
-  return x[`vip${num}`]();
+export const loadProposal = async (path: string) => {
+  const proposalModule = await import(`../vips/${path}`);
+  return proposalModule.default();
 };
 
-export const proposeVIP = async (vipNumber: string, governorProxyAddress?: string) => {
-  const proposal = await loadProposal(vipNumber);
+export const proposeVIP = async (vipPath: string, governorProxyAddress?: string) => {
+  const proposal = await loadProposal(vipPath);
 
   const { targets, signatures, values, meta } = proposal;
 


### PR DESCRIPTION
## Description

Currently the proposal hard hat commands don't support the current repo structure of organizing proposals in directories. This PR updates to support arbitrary file paths and function names. 
When running the hardhat commands instead of declaring the proposal number you pass the path. It also requires the proposal creation function to be the default export which decouples the name of the function from consumers of the function

Resolves VEN<!-- issue id -->
