### PR TITLE
[VEN-2370]: move VAI/USDT liquidity from PCS v2 to PCS v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@venusprotocol/token-bridge": "^1.1.0",
     "@venusprotocol/venus-protocol": "^7.4.0",
     "ajv": "^8.12.0",
+    "decimal.js": "^10.4.3",
     "readline-sync": "^1.4.10"
   },
   "devDependencies": {

--- a/simulations/vip-285/abi/IERC20UpgradableAbi.json
+++ b/simulations/vip-285/abi/IERC20UpgradableAbi.json
@@ -1,0 +1,295 @@
+[
+  {
+    "inputs": [
+      { "internalType": "string", "name": "name_", "type": "string" },
+      { "internalType": "string", "name": "symbol_", "type": "string" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "spender", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "userAddress", "type": "address" },
+      { "indexed": false, "internalType": "address payable", "name": "relayerAddress", "type": "address" },
+      { "indexed": false, "internalType": "bytes", "name": "functionSignature", "type": "bytes" }
+    ],
+    "name": "MetaTransactionExecuted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "indexed": true, "internalType": "bytes32", "name": "previousAdminRole", "type": "bytes32" },
+      { "indexed": true, "internalType": "bytes32", "name": "newAdminRole", "type": "bytes32" }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "account", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "sender", "type": "address" }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "account", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "sender", "type": "address" }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ERC712_VERSION",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PREDICATE_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "subtractedValue", "type": "uint256" }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "userAddress", "type": "address" },
+      { "internalType": "bytes", "name": "functionSignature", "type": "bytes" },
+      { "internalType": "bytes32", "name": "sigR", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "sigS", "type": "bytes32" },
+      { "internalType": "uint8", "name": "sigV", "type": "uint8" }
+    ],
+    "name": "executeMetaTransaction",
+    "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getChainId",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getDomainSeperator",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "user", "type": "address" }],
+    "name": "getNonce",
+    "outputs": [{ "internalType": "uint256", "name": "nonce", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "role", "type": "bytes32" }],
+    "name": "getRoleAdmin",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "uint256", "name": "index", "type": "uint256" }
+    ],
+    "name": "getRoleMember",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "role", "type": "bytes32" }],
+    "name": "getRoleMemberCount",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "hasRole",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "addedValue", "type": "uint256" }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "sender", "type": "address" },
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/simulations/vip-285/abi/NonfungiblePositionManager.json
+++ b/simulations/vip-285/abi/NonfungiblePositionManager.json
@@ -1,0 +1,505 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_deployer", "type": "address" },
+      { "internalType": "address", "name": "_factory", "type": "address" },
+      { "internalType": "address", "name": "_WETH9", "type": "address" },
+      { "internalType": "address", "name": "_tokenDescriptor_", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "approved", "type": "address" },
+      { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "operator", "type": "address" },
+      { "indexed": false, "internalType": "bool", "name": "approved", "type": "bool" }
+    ],
+    "name": "ApprovalForAll",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+      { "indexed": false, "internalType": "address", "name": "recipient", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount0", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "amount1", "type": "uint256" }
+    ],
+    "name": "Collect",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+      { "indexed": false, "internalType": "uint128", "name": "liquidity", "type": "uint128" },
+      { "indexed": false, "internalType": "uint256", "name": "amount0", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "amount1", "type": "uint256" }
+    ],
+    "name": "DecreaseLiquidity",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+      { "indexed": false, "internalType": "uint128", "name": "liquidity", "type": "uint128" },
+      { "indexed": false, "internalType": "uint256", "name": "amount0", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "amount1", "type": "uint256" }
+    ],
+    "name": "IncreaseLiquidity",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": true, "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DOMAIN_SEPARATOR",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PERMIT_TYPEHASH",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "WETH9",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "baseURI",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "tokenId", "type": "uint256" }],
+    "name": "burn",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+          { "internalType": "address", "name": "recipient", "type": "address" },
+          { "internalType": "uint128", "name": "amount0Max", "type": "uint128" },
+          { "internalType": "uint128", "name": "amount1Max", "type": "uint128" }
+        ],
+        "internalType": "struct INonfungiblePositionManager.CollectParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "collect",
+    "outputs": [
+      { "internalType": "uint256", "name": "amount0", "type": "uint256" },
+      { "internalType": "uint256", "name": "amount1", "type": "uint256" }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token0", "type": "address" },
+      { "internalType": "address", "name": "token1", "type": "address" },
+      { "internalType": "uint24", "name": "fee", "type": "uint24" },
+      { "internalType": "uint160", "name": "sqrtPriceX96", "type": "uint160" }
+    ],
+    "name": "createAndInitializePoolIfNecessary",
+    "outputs": [{ "internalType": "address", "name": "pool", "type": "address" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+          { "internalType": "uint128", "name": "liquidity", "type": "uint128" },
+          { "internalType": "uint256", "name": "amount0Min", "type": "uint256" },
+          { "internalType": "uint256", "name": "amount1Min", "type": "uint256" },
+          { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+        ],
+        "internalType": "struct INonfungiblePositionManager.DecreaseLiquidityParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "decreaseLiquidity",
+    "outputs": [
+      { "internalType": "uint256", "name": "amount0", "type": "uint256" },
+      { "internalType": "uint256", "name": "amount1", "type": "uint256" }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "deployer",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factory",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "tokenId", "type": "uint256" }],
+    "name": "getApproved",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+          { "internalType": "uint256", "name": "amount0Desired", "type": "uint256" },
+          { "internalType": "uint256", "name": "amount1Desired", "type": "uint256" },
+          { "internalType": "uint256", "name": "amount0Min", "type": "uint256" },
+          { "internalType": "uint256", "name": "amount1Min", "type": "uint256" },
+          { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+        ],
+        "internalType": "struct INonfungiblePositionManager.IncreaseLiquidityParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "increaseLiquidity",
+    "outputs": [
+      { "internalType": "uint128", "name": "liquidity", "type": "uint128" },
+      { "internalType": "uint256", "name": "amount0", "type": "uint256" },
+      { "internalType": "uint256", "name": "amount1", "type": "uint256" }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "operator", "type": "address" }
+    ],
+    "name": "isApprovedForAll",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "token0", "type": "address" },
+          { "internalType": "address", "name": "token1", "type": "address" },
+          { "internalType": "uint24", "name": "fee", "type": "uint24" },
+          { "internalType": "int24", "name": "tickLower", "type": "int24" },
+          { "internalType": "int24", "name": "tickUpper", "type": "int24" },
+          { "internalType": "uint256", "name": "amount0Desired", "type": "uint256" },
+          { "internalType": "uint256", "name": "amount1Desired", "type": "uint256" },
+          { "internalType": "uint256", "name": "amount0Min", "type": "uint256" },
+          { "internalType": "uint256", "name": "amount1Min", "type": "uint256" },
+          { "internalType": "address", "name": "recipient", "type": "address" },
+          { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+        ],
+        "internalType": "struct INonfungiblePositionManager.MintParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "mint",
+    "outputs": [
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+      { "internalType": "uint128", "name": "liquidity", "type": "uint128" },
+      { "internalType": "uint256", "name": "amount0", "type": "uint256" },
+      { "internalType": "uint256", "name": "amount1", "type": "uint256" }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes[]", "name": "data", "type": "bytes[]" }],
+    "name": "multicall",
+    "outputs": [{ "internalType": "bytes[]", "name": "results", "type": "bytes[]" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "tokenId", "type": "uint256" }],
+    "name": "ownerOf",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount0Owed", "type": "uint256" },
+      { "internalType": "uint256", "name": "amount1Owed", "type": "uint256" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" }
+    ],
+    "name": "pancakeV3MintCallback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" },
+      { "internalType": "uint8", "name": "v", "type": "uint8" },
+      { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+    ],
+    "name": "permit",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "tokenId", "type": "uint256" }],
+    "name": "positions",
+    "outputs": [
+      { "internalType": "uint96", "name": "nonce", "type": "uint96" },
+      { "internalType": "address", "name": "operator", "type": "address" },
+      { "internalType": "address", "name": "token0", "type": "address" },
+      { "internalType": "address", "name": "token1", "type": "address" },
+      { "internalType": "uint24", "name": "fee", "type": "uint24" },
+      { "internalType": "int24", "name": "tickLower", "type": "int24" },
+      { "internalType": "int24", "name": "tickUpper", "type": "int24" },
+      { "internalType": "uint128", "name": "liquidity", "type": "uint128" },
+      { "internalType": "uint256", "name": "feeGrowthInside0LastX128", "type": "uint256" },
+      { "internalType": "uint256", "name": "feeGrowthInside1LastX128", "type": "uint256" },
+      { "internalType": "uint128", "name": "tokensOwed0", "type": "uint128" },
+      { "internalType": "uint128", "name": "tokensOwed1", "type": "uint128" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "refundETH", "outputs": [], "stateMutability": "payable", "type": "function" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
+      { "internalType": "bytes", "name": "_data", "type": "bytes" }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" },
+      { "internalType": "uint8", "name": "v", "type": "uint8" },
+      { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+    ],
+    "name": "selfPermit",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "nonce", "type": "uint256" },
+      { "internalType": "uint256", "name": "expiry", "type": "uint256" },
+      { "internalType": "uint8", "name": "v", "type": "uint8" },
+      { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+    ],
+    "name": "selfPermitAllowed",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "nonce", "type": "uint256" },
+      { "internalType": "uint256", "name": "expiry", "type": "uint256" },
+      { "internalType": "uint8", "name": "v", "type": "uint8" },
+      { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+    ],
+    "name": "selfPermitAllowedIfNecessary",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" },
+      { "internalType": "uint8", "name": "v", "type": "uint8" },
+      { "internalType": "bytes32", "name": "r", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "s", "type": "bytes32" }
+    ],
+    "name": "selfPermitIfNecessary",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "operator", "type": "address" },
+      { "internalType": "bool", "name": "approved", "type": "bool" }
+    ],
+    "name": "setApprovalForAll",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes4", "name": "interfaceId", "type": "bytes4" }],
+    "name": "supportsInterface",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "token", "type": "address" },
+      { "internalType": "uint256", "name": "amountMinimum", "type": "uint256" },
+      { "internalType": "address", "name": "recipient", "type": "address" }
+    ],
+    "name": "sweepToken",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "index", "type": "uint256" }],
+    "name": "tokenByIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "uint256", "name": "index", "type": "uint256" }
+    ],
+    "name": "tokenOfOwnerByIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "tokenId", "type": "uint256" }],
+    "name": "tokenURI",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amountMinimum", "type": "uint256" },
+      { "internalType": "address", "name": "recipient", "type": "address" }
+    ],
+    "name": "unwrapWETH9",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  { "stateMutability": "payable", "type": "receive" }
+]

--- a/simulations/vip-285/abi/VTreasury.json
+++ b/simulations/vip-285/abi/VTreasury.json
@@ -1,0 +1,83 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "tokenAddress", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "withdrawAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "address", "name": "withdrawAddress", "type": "address" }
+    ],
+    "name": "WithdrawTreasuryBEP20",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "withdrawAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "address", "name": "withdrawAddress", "type": "address" }
+    ],
+    "name": "WithdrawTreasuryBNB",
+    "type": "event"
+  },
+  { "payable": true, "stateMutability": "payable", "type": "fallback" },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "newOwner", "type": "address" }],
+    "name": "transferOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "tokenAddress", "type": "address" },
+      { "internalType": "uint256", "name": "withdrawAmount", "type": "uint256" },
+      { "internalType": "address", "name": "withdrawAddress", "type": "address" }
+    ],
+    "name": "withdrawTreasuryBEP20",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "uint256", "name": "withdrawAmount", "type": "uint256" },
+      { "internalType": "address payable", "name": "withdrawAddress", "type": "address" }
+    ],
+    "name": "withdrawTreasuryBNB",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]

--- a/simulations/vip-285/bscmainnet.ts
+++ b/simulations/vip-285/bscmainnet.ts
@@ -1,0 +1,153 @@
+import { TransactionReceipt, TransactionResponse } from "@ethersproject/providers";
+import { expect } from "chai";
+import Decimal from "decimal.js";
+import { BigNumber } from "ethers";
+import { formatUnits, parseUnits } from "ethers/lib/utils";
+import { ethers } from "hardhat";
+
+import { NORMAL_TIMELOCK, forking, testVip } from "../../src/vip-framework";
+import { MAX_TICK_CENTER, MIN_TICK_CENTER, TICK_SPREAD, vip285 } from "../../vips/vip-285/bscmainnet";
+import IERC20_ABI from "./abi/IERC20UpgradableAbi.json";
+import V3_POSITION_MANAGER_ABI from "./abi/NonfungiblePositionManager.json";
+
+const USDT = "0x55d398326f99059ff775485246999027b3197955";
+const VAI = "0x4BD17003473389A42DAF6a0a729f6Fdb328BbBd7";
+const V2_LP = "0xD94FeFc80a7d10d4708b140c7210569061a7eddb";
+const V3_POSITION_MANAGER = "0x46A15B0b27311cedF172AB29E4f4766fbE7F4364";
+const LIQUIDITY_MOVER = "0xcE18DA58f469A2dA9decDf1B168494240430D1D4";
+const TREASURY = "0xF322942f644A996A617BD29c16bd7d231d9F35E9";
+
+// Actual refunds will depend on the amounts of USDT and VAI
+// received from v2 LP, the additional VAI deposited from timelock,
+// and the current state of the PCS v3 pool.
+// The numbers are calculated based on the fork block.
+const EXPECTED_USDT_REFUND = parseUnits("0", 18);
+const EXPECTED_VAI_REFUND = parseUnits("2668.754702575565935377", 18);
+
+export const tickToPrice = (tick: number): BigNumber => {
+  const E18 = new Decimal(10).pow(18);
+  return BigNumber.from(new Decimal("1.0001").pow(tick).mul(E18).toFixed(0));
+};
+
+const formatPrice = (tick: number) => {
+  return formatUnits(tickToPrice(tick), 18);
+};
+
+const formatPriceRange = (tickCenter: number, tickSpread: number) => {
+  const tickLower = tickCenter - tickSpread;
+  const tickUpper = tickCenter + tickSpread + 1; // +1 because the upper bound is exclusive
+  return `${formatPrice(tickLower)} - ${formatPrice(tickUpper)}`;
+};
+
+console.log(`
+The VIP withdraws an USDT and VAI from PCS v2 pool, proportional to
+the current price, and then resupplies USDT and VAI to the neighborhood
+of the **current** PCS v3 price.
+
+Under the hood, the prices and the neighborhood are expressed in ticks.
+
+The following tick values are used in this VIP:
+  * neighborhood: ${TICK_SPREAD} ticks, which, if VAI costs exactly 1 USDT, corresponds to ${formatPriceRange(
+  0,
+  TICK_SPREAD,
+)} USDT/VAI.
+  * min tick center: ${MIN_TICK_CENTER}, which corresponds to the spot price of ${formatPrice(
+  MIN_TICK_CENTER,
+)} USDT/VAI.
+    - this means that the minimum possible price range would be ${formatPriceRange(
+      MIN_TICK_CENTER,
+      TICK_SPREAD,
+    )} USDT/VAI.
+  * max tick center: ${MAX_TICK_CENTER}, which corresponds to the spot price of ${formatPrice(
+  MAX_TICK_CENTER,
+)} USDT/VAI.
+    - this means that the maximum possible price range would be ${formatPriceRange(
+      MAX_TICK_CENTER,
+      TICK_SPREAD,
+    )} USDT/VAI.
+`);
+
+forking(37624600, () => {
+  const usdt = new ethers.Contract(USDT, IERC20_ABI, ethers.provider);
+  const vai = new ethers.Contract(VAI, IERC20_ABI, ethers.provider);
+  const v2lp = new ethers.Contract(V2_LP, IERC20_ABI, ethers.provider);
+  const v3pm = new ethers.Contract(V3_POSITION_MANAGER, V3_POSITION_MANAGER_ABI, ethers.provider);
+
+  let treasuryUsdtBalanceBefore: BigNumber;
+  let treasuryVaiBalanceBefore: BigNumber;
+  let executionTx: TransactionResponse;
+  let executionTxReceipt: TransactionReceipt;
+
+  before(async () => {
+    treasuryUsdtBalanceBefore = await usdt.balanceOf(TREASURY);
+    treasuryVaiBalanceBefore = await vai.balanceOf(TREASURY);
+  });
+
+  testVip("VIP-285", vip285(), {
+    callbackAfterExecution: async tx => {
+      executionTx = tx;
+      executionTxReceipt = await tx.wait();
+    },
+  });
+
+  describe("Post-VIP state", () => {
+    const positionId = (() => {
+      let _positionId: BigNumber | undefined;
+      return () => {
+        if (_positionId !== undefined) {
+          return _positionId;
+        }
+        const increaseLiquidityEvent = executionTxReceipt.logs
+          .filter(({ address }) => address === V3_POSITION_MANAGER)
+          .map(logEntry => v3pm.interface.parseLog(logEntry))
+          .find(({ name }) => name === "IncreaseLiquidity");
+        _positionId = increaseLiquidityEvent?.args.tokenId;
+        if (_positionId === undefined) {
+          throw new Error("IncreaseLiquidity event not found");
+        }
+        return _positionId;
+      };
+    })();
+
+    it("should emit IncreaseLiquidity event", async () => {
+      await expect(executionTx).to.emit(v3pm, "IncreaseLiquidity");
+    });
+
+    it("should increase liquidity in PCS v3", async () => {
+      const position = await v3pm.positions(positionId());
+      expect(position.liquidity).to.not.equal(0);
+    });
+
+    it("should transfer all V2 LP tokens from treasury", async () => {
+      expect(await v2lp.balanceOf(TREASURY)).to.equal(0);
+    });
+
+    it("should leave no V2 LP tokens in liquidity mover", async () => {
+      expect(await v2lp.balanceOf(LIQUIDITY_MOVER)).to.equal(0);
+    });
+
+    it("should leave no USDT in liquidity mover", async () => {
+      expect(await usdt.balanceOf(LIQUIDITY_MOVER)).to.equal(0);
+    });
+
+    it("should leave no VAI in liquidity mover", async () => {
+      expect(await vai.balanceOf(LIQUIDITY_MOVER)).to.equal(0);
+    });
+
+    it(`should increase USDT balance in treasury by ${formatUnits(EXPECTED_USDT_REFUND, 18)}`, async () => {
+      const treasuryUsdtBalanceAfter = await usdt.balanceOf(TREASURY);
+      const delta = treasuryUsdtBalanceAfter.sub(treasuryUsdtBalanceBefore);
+      expect(delta).to.equal(EXPECTED_USDT_REFUND);
+    });
+
+    it(`should increase VAI balance in treasury by ${formatUnits(EXPECTED_VAI_REFUND, 18)}`, async () => {
+      const treasuryVaiBalanceAfter = await vai.balanceOf(TREASURY);
+      const delta = treasuryVaiBalanceAfter.sub(treasuryVaiBalanceBefore);
+      expect(delta).to.equal(EXPECTED_VAI_REFUND);
+    });
+
+    it(`should send the NFT to the timelock`, async () => {
+      expect(await v3pm.ownerOf(positionId())).to.equal(NORMAL_TIMELOCK);
+    });
+  });
+});

--- a/vips/vip-285/bscmainnet.ts
+++ b/vips/vip-285/bscmainnet.ts
@@ -1,0 +1,91 @@
+import { parseUnits } from "ethers/lib/utils";
+
+import { ProposalType } from "../../src/types";
+import { makeProposal } from "../../src/utils";
+import { NORMAL_TIMELOCK } from "../../src/vip-framework";
+
+const TREASURY = "0xF322942f644A996A617BD29c16bd7d231d9F35E9";
+const VAI = "0x4BD17003473389A42DAF6a0a729f6Fdb328BbBd7";
+const V2_LP = "0xD94FeFc80a7d10d4708b140c7210569061a7eddb";
+const V2_LP_BALANCE = parseUnits("176508.405573652762506292", 18);
+const TIMELOCK_VAI_BALANCE = parseUnits("1598.336577715436018042", 18);
+const LIQUIDITY_MOVER = "0xcE18DA58f469A2dA9decDf1B168494240430D1D4";
+
+const MIN_VAI = parseUnits("180000", 18);
+const MIN_USDT = parseUnits("180000", 18);
+const V3_POOL_FEE = 100;
+export const MIN_TICK_CENTER = -100;
+export const MAX_TICK_CENTER = 100;
+export const TICK_SPREAD = 250;
+
+const DEADLINE = 1712790000; // April 10th, 2024, 23:00 UTC
+
+export const vip285 = () => {
+  const meta = {
+    version: "v1",
+    title: "VIP-285 Move from PancakeSwap V2 to PancakeSwap V3 the protocol USDT/VAI liquidity",
+    description: `#### Summary
+
+If passed, this VIP will perform the following actions:
+
+* Redeem PancakeSwap v2 LP tokens from the [v2 pool](https://pancakeswap.finance/info/pairs/0xD94FeFc80a7d10d4708b140c7210569061a7eddb?chain=bsc), supplied at [VIP-108](https://app.venus.io/#/governance/proposal/108?chainId=56)
+* Deposit the received USDT/VAI to a PCS v3 pool (plus 1,598 VAI held by the Normal Timelock, not used at VIP-108)
+
+#### Specifications
+
+This VIP redeems PancakeSwap v2 LP tokens from the [v2 pool](https://pancakeswap.finance/info/pairs/0xD94FeFc80a7d10d4708b140c7210569061a7eddb?chain=bsc) (previously supplied at [VIP-108](https://app.venus.io/#/governance/proposal/108?chainId=56)) and deposits the received USDT/VAI to a PCS v3 pool. The range is 500 ticks concentrated somewhere between [0.966, 1.036] depending on the current spot price.
+
+* The lowest possible range is if the spot price is 0.990 USDT/VAI, it's equal to [0.966, 1.015]
+* The highest possible range is if the spot price is 1.010 USDT/VAI, it's equal to [0.985, 1.035]
+* If the spot price is lower than 0.990 USDT/VAI or higher than 1.010 USDT/VAI, the VIP will not be executable until the spot price is back to expected values
+
+This approach allows for maximizing the supplied amount since the tokens are added proportionally and no excess of a single token is required.
+
+The minted NFT token will be sent to the [Normal Timelock](https://bscscan.com/address/0x939bD8d64c0A9583A7Dcea9933f7b21697ab6396). The [Venus Treasury](https://bscscan.com/address/0xf322942f644a996a617bd29c16bd7d231d9f35e9) will receive the surplus liquidity.
+
+This VIP uses a intermediary contract to perform the movement: [LiquidityMover](https://bscscan.com/address/0xcE18DA58f469A2dA9decDf1B168494240430D1D4)
+
+VIP simulation: [https://github.com/VenusProtocol/vips/pull/213](https://github.com/VenusProtocol/vips/pull/213)
+`,
+    forDescription: "I agree that Venus Protocol should proceed with this proposal",
+    againstDescription: "I do not think that Venus Protocol should proceed with this proposal",
+    abstainDescription: "I am indifferent to whether Venus Protocol proceeds or not",
+  };
+
+  return makeProposal(
+    [
+      {
+        target: TREASURY,
+        signature: "withdrawTreasuryBEP20(address,uint256,address)",
+        params: [V2_LP, V2_LP_BALANCE, LIQUIDITY_MOVER],
+      },
+      {
+        target: VAI,
+        signature: "transfer(address,uint256)",
+        params: [LIQUIDITY_MOVER, TIMELOCK_VAI_BALANCE],
+      },
+      {
+        target: LIQUIDITY_MOVER,
+        signature: "moveLiquidity((address,uint256,uint256,uint24,int24,int24,int24,address,address,uint256))",
+        params: [
+          [
+            V2_LP,
+            MIN_VAI,
+            MIN_USDT,
+            V3_POOL_FEE,
+            MIN_TICK_CENTER,
+            MAX_TICK_CENTER,
+            TICK_SPREAD,
+            NORMAL_TIMELOCK,
+            TREASURY,
+            DEADLINE,
+          ],
+        ],
+      },
+    ],
+    meta,
+    ProposalType.REGULAR,
+  );
+};
+
+export default vip285;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2879,6 +2879,7 @@ __metadata:
     commitizen: ^4.2.5
     cross-env: ^7.0.3
     cz-conventional-changelog: ^3.3.0
+    decimal.js: ^10.4.3
     dotenv: ^16.0.3
     eslint: ^8.28.0
     eslint-config-prettier: ^8.5.0
@@ -4624,6 +4625,13 @@ __metadata:
   version: 4.0.0
   resolution: "decamelize@npm:4.0.0"
   checksum: b7d09b82652c39eead4d6678bb578e3bebd848add894b76d0f6b395bc45b2d692fb88d977e7cfb93c4ed6c119b05a1347cef261174916c2e75c0a8ca57da1809
+  languageName: node
+  linkType: hard
+
+"decimal.js@npm:^10.4.3":
+  version: 10.4.3
+  resolution: "decimal.js@npm:10.4.3"
+  checksum: 796404dcfa9d1dbfdc48870229d57f788b48c21c603c3f6554a1c17c10195fc1024de338b0cf9e1efe0c7c167eeb18f04548979bcc5fdfabebb7cc0ae3287bae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This VIP redeems PCS v2 LP tokens from the v2 pool and deposits the received USDT/VAI to a PCS v3 pool. The range is 500 ticks concentrated somewhere between [0.966, 1.036] depending on the current spot price.

* The lowest possible range is if the spot price is 0.990 USDT/VAI, it's equal to [0.966, 1.015]
* The highest possible range is if the spot price is 1.010 USDT/VAI, it's equal to [0.985, 1.035]
* If the spot price is lower than 0.990 USDT/VAI or higher than 1.010 USDT/VAI, the transaction will revert

Although the proposed approach is a bit non-deterministic in terms of the resulting range, it allows for maximizing the supplied amount since the tokens are added proportionally and no excess of a single token is required.

The temporary contract that does the operation is at https://github.com/VenusProtocol/venus-protocol/compare/develop...feat/liquidity-mover