### PR TITLE
[VEN-2759]: Chaos Labs recommendations (Aug, 15, 2024)

### DIFF
--- a/multisig/proposals/arbitrumone/vip-010/index.ts
+++ b/multisig/proposals/arbitrumone/vip-010/index.ts
@@ -1,0 +1,21 @@
+import { makeProposal } from "src/utils";
+
+export const VUSDC_CORE = "0x7D8609f8da70fF9027E9bc5229Af4F6727662707";
+export const VUSDT_CORE = "0xB9F9117d4200dC296F9AcD1e8bE1937df834a2fD";
+
+export const RATE_MODELS = {
+  JumpRateModelV2_base0bps_slope875bps_jump25000bps_kink8000bps: "0xC7EDE29FE265aA46C1Bbc62Dc7e0f3565cce3Db6",
+  JumpRateModelV2_base0bps_slope800bps_jump25000bps_kink8000bps: "0x42888177eB8FcdEa0884De66c7E0f7638125914A",
+};
+
+const vip010 = () => {
+  return makeProposal([
+    ...[VUSDC_CORE, VUSDT_CORE].map((vToken: string) => ({
+      target: vToken,
+      signature: "setInterestRateModel(address)",
+      params: [RATE_MODELS.JumpRateModelV2_base0bps_slope800bps_jump25000bps_kink8000bps],
+    })),
+  ]);
+};
+
+export default vip010;

--- a/multisig/proposals/ethereum/vip-055/index.ts
+++ b/multisig/proposals/ethereum/vip-055/index.ts
@@ -1,0 +1,29 @@
+import { makeProposal } from "src/utils";
+
+export const VDAI_CORE = "0xd8AdD9B41D4E1cd64Edad8722AB0bA8D35536657";
+export const VCRVUSD_CORE = "0x672208C10aaAA2F9A6719F449C4C8227bc0BC202";
+export const VTUSD_CORE = "0x13eB80FDBe5C5f4a7039728E258A6f05fb3B912b";
+
+export const RATE_MODELS = {
+  JumpRateModelV2_base0bps_slope1500bps_jump25000bps_kink8000bps_alternative:
+    "0x5C690C694eca13Ac540DD5777a9605503f654033",
+  JumpRateModelV2_base0bps_slope875bps_jump25000bps_kink8000bps: "0xD9D3E7adA04993Cf06dE1A5c9C7f101BD1DefBF4",
+  JumpRateModelV2_base0bps_slope1500bps_jump25000bps_kink8000bps: "0x244dBE6d11Ae9AadBaD552E6BD8901B680028E31",
+};
+
+const vip055 = () => {
+  return makeProposal([
+    ...[VDAI_CORE, VTUSD_CORE].map((vToken: string) => ({
+      target: vToken,
+      signature: "setInterestRateModel(address)",
+      params: [RATE_MODELS.JumpRateModelV2_base0bps_slope875bps_jump25000bps_kink8000bps],
+    })),
+    {
+      target: VCRVUSD_CORE,
+      signature: "setInterestRateModel(address)",
+      params: [RATE_MODELS.JumpRateModelV2_base0bps_slope1500bps_jump25000bps_kink8000bps],
+    },
+  ]);
+};
+
+export default vip055;

--- a/multisig/simulations/arbitrumone/vip-010/abi/VTokenIL.json
+++ b/multisig/simulations/arbitrumone/vip-010/abi/VTokenIL.json
@@ -1,0 +1,861 @@
+[
+  { "inputs": [], "stateMutability": "nonpayable", "type": "constructor" },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "actualAddAmount", "type": "uint256" }],
+    "name": "AddReservesFactorFreshCheck",
+    "type": "error"
+  },
+  { "inputs": [], "name": "BorrowCashNotAvailable", "type": "error" },
+  { "inputs": [], "name": "BorrowFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "DelegateNotApproved", "type": "error" },
+  { "inputs": [], "name": "ForceLiquidateBorrowUnauthorized", "type": "error" },
+  { "inputs": [], "name": "HealBorrowUnauthorized", "type": "error" },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "errorCode", "type": "uint256" }],
+    "name": "LiquidateAccrueCollateralInterestFailed",
+    "type": "error"
+  },
+  { "inputs": [], "name": "LiquidateCloseAmountIsUintMax", "type": "error" },
+  { "inputs": [], "name": "LiquidateCloseAmountIsZero", "type": "error" },
+  { "inputs": [], "name": "LiquidateCollateralFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "LiquidateFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "LiquidateLiquidatorIsBorrower", "type": "error" },
+  { "inputs": [], "name": "LiquidateSeizeLiquidatorIsBorrower", "type": "error" },
+  { "inputs": [], "name": "MintFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "ProtocolSeizeShareTooBig", "type": "error" },
+  { "inputs": [], "name": "RedeemFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "RedeemTransferOutNotPossible", "type": "error" },
+  { "inputs": [], "name": "ReduceReservesCashNotAvailable", "type": "error" },
+  { "inputs": [], "name": "ReduceReservesCashValidation", "type": "error" },
+  { "inputs": [], "name": "ReduceReservesFreshCheck", "type": "error" },
+  { "inputs": [], "name": "RepayBorrowFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "SetInterestRateModelFreshCheck", "type": "error" },
+  { "inputs": [], "name": "SetReserveFactorBoundsCheck", "type": "error" },
+  { "inputs": [], "name": "SetReserveFactorFreshCheck", "type": "error" },
+  { "inputs": [], "name": "TransferNotAllowed", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "sender", "type": "address" },
+      { "internalType": "address", "name": "calledContract", "type": "address" },
+      { "internalType": "string", "name": "methodSignature", "type": "string" }
+    ],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  { "inputs": [], "name": "ZeroAddressNotAllowed", "type": "error" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "cashPrior", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "interestAccumulated", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "borrowIndex", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "AccrueInterest",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "spender", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "badDebtDelta", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "badDebtOld", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "badDebtNew", "type": "uint256" }
+    ],
+    "name": "BadDebtIncreased",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "badDebtOld", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "badDebtNew", "type": "uint256" }
+    ],
+    "name": "BadDebtRecovered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "borrowAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBorrows", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "Borrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "payer", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "HealBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "uint8", "name": "version", "type": "uint8" }],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "liquidator", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "indexed": true, "internalType": "address", "name": "vTokenCollateral", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "LiquidateBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "minter", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "mintAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "mintTokens", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBalance", "type": "uint256" }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldAccessControlManager", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newAccessControlManager", "type": "address" }
+    ],
+    "name": "NewAccessControlManager",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract ComptrollerInterface", "name": "oldComptroller", "type": "address" },
+      { "indexed": true, "internalType": "contract ComptrollerInterface", "name": "newComptroller", "type": "address" }
+    ],
+    "name": "NewComptroller",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract InterestRateModel",
+        "name": "oldInterestRateModel",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "contract InterestRateModel",
+        "name": "newInterestRateModel",
+        "type": "address"
+      }
+    ],
+    "name": "NewMarketInterestRateModel",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldProtocolSeizeShareMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newProtocolSeizeShareMantissa", "type": "uint256" }
+    ],
+    "name": "NewProtocolSeizeShare",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "oldProtocolShareReserve", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newProtocolShareReserve", "type": "address" }
+    ],
+    "name": "NewProtocolShareReserve",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldReduceReservesBlockDelta", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newReduceReservesBlockDelta", "type": "uint256" }
+    ],
+    "name": "NewReduceReservesBlockDelta",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldReserveFactorMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newReserveFactorMantissa", "type": "uint256" }
+    ],
+    "name": "NewReserveFactor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "oldShortfall", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newShortfall", "type": "address" }
+    ],
+    "name": "NewShortfallContract",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "ProtocolSeize",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "redeemer", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "redeemAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "redeemTokens", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBalance", "type": "uint256" }
+    ],
+    "name": "Redeem",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "payer", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBorrows", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "RepayBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "benefactor", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "addAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newTotalReserves", "type": "uint256" }
+    ],
+    "name": "ReservesAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "protocolShareReserve", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "reduceAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newTotalReserves", "type": "uint256" }
+    ],
+    "name": "SpreadReservesReduced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": true, "internalType": "address", "name": "token", "type": "address" }],
+    "name": "SweepToken",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "NO_ERROR",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "acceptOwnership", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [],
+    "name": "accessControlManager",
+    "outputs": [{ "internalType": "contract IAccessControlManagerV8", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accrualBlockNumber",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accrueInterest",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "addAmount", "type": "uint256" }],
+    "name": "addReserves",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "badDebt",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "recoveredAmount_", "type": "uint256" }],
+    "name": "badDebtRecovered",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "balanceOfUnderlying",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }],
+    "name": "borrow",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "borrowBalanceCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "borrowBalanceStored",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }
+    ],
+    "name": "borrowBehalf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "borrowIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "borrowRatePerBlock",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "comptroller",
+    "outputs": [{ "internalType": "contract ComptrollerInterface", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "subtractedValue", "type": "uint256" }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "exchangeRateCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "exchangeRateStored",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "internalType": "contract VTokenInterface", "name": "vTokenCollateral", "type": "address" },
+      { "internalType": "bool", "name": "skipLiquidityCheck", "type": "bool" }
+    ],
+    "name": "forceLiquidateBorrow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "getAccountSnapshot",
+    "outputs": [
+      { "internalType": "uint256", "name": "error", "type": "uint256" },
+      { "internalType": "uint256", "name": "vTokenBalance", "type": "uint256" },
+      { "internalType": "uint256", "name": "borrowBalance", "type": "uint256" },
+      { "internalType": "uint256", "name": "exchangeRate", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCash",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "payer", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "healBorrow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "addedValue", "type": "uint256" }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "underlying_", "type": "address" },
+      { "internalType": "contract ComptrollerInterface", "name": "comptroller_", "type": "address" },
+      { "internalType": "contract InterestRateModel", "name": "interestRateModel_", "type": "address" },
+      { "internalType": "uint256", "name": "initialExchangeRateMantissa_", "type": "uint256" },
+      { "internalType": "string", "name": "name_", "type": "string" },
+      { "internalType": "string", "name": "symbol_", "type": "string" },
+      { "internalType": "uint8", "name": "decimals_", "type": "uint8" },
+      { "internalType": "address", "name": "admin_", "type": "address" },
+      { "internalType": "address", "name": "accessControlManager_", "type": "address" },
+      {
+        "components": [
+          { "internalType": "address", "name": "shortfall", "type": "address" },
+          { "internalType": "address payable", "name": "protocolShareReserve", "type": "address" }
+        ],
+        "internalType": "struct VTokenInterface.RiskManagementInit",
+        "name": "riskManagement",
+        "type": "tuple"
+      },
+      { "internalType": "uint256", "name": "reserveFactorMantissa_", "type": "uint256" }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "interestRateModel",
+    "outputs": [{ "internalType": "contract InterestRateModel", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isVToken",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "internalType": "contract VTokenInterface", "name": "vTokenCollateral", "type": "address" }
+    ],
+    "name": "liquidateBorrow",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "mintAmount", "type": "uint256" }],
+    "name": "mint",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "minter", "type": "address" },
+      { "internalType": "uint256", "name": "mintAmount", "type": "uint256" }
+    ],
+    "name": "mintBehalf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolSeizeShareMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolShareReserve",
+    "outputs": [{ "internalType": "address payable", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }],
+    "name": "redeem",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "redeemer", "type": "address" },
+      { "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }
+    ],
+    "name": "redeemBehalf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "redeemAmount", "type": "uint256" }],
+    "name": "redeemUnderlying",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "redeemer", "type": "address" },
+      { "internalType": "uint256", "name": "redeemAmount", "type": "uint256" }
+    ],
+    "name": "redeemUnderlyingBehalf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "reduceAmount", "type": "uint256" }],
+    "name": "reduceReserves",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reduceReservesBlockDelta",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reduceReservesBlockNumber",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "renounceOwnership", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "repayAmount", "type": "uint256" }],
+    "name": "repayBorrow",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "repayBorrowBehalf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserveFactorMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "seize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "accessControlManager_", "type": "address" }],
+    "name": "setAccessControlManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "contract InterestRateModel", "name": "newInterestRateModel", "type": "address" }],
+    "name": "setInterestRateModel",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "newProtocolSeizeShareMantissa_", "type": "uint256" }],
+    "name": "setProtocolSeizeShare",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address payable", "name": "protocolShareReserve_", "type": "address" }],
+    "name": "setProtocolShareReserve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_newReduceReservesBlockDelta", "type": "uint256" }],
+    "name": "setReduceReservesBlockDelta",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "newReserveFactorMantissa", "type": "uint256" }],
+    "name": "setReserveFactor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "shortfall_", "type": "address" }],
+    "name": "setShortfallContract",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "shortfall",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "supplyRatePerBlock",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "contract IERC20Upgradeable", "name": "token", "type": "address" }],
+    "name": "sweepToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalBorrows",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalBorrowsCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalReserves",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "src", "type": "address" },
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "newOwner", "type": "address" }],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "underlying",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/multisig/simulations/arbitrumone/vip-010/index.ts
+++ b/multisig/simulations/arbitrumone/vip-010/index.ts
@@ -1,0 +1,69 @@
+import { expect } from "chai";
+import { BigNumber } from "ethers";
+import { ethers } from "hardhat";
+import { forking, pretendExecutingVip } from "src/vip-framework";
+import { checkInterestRate } from "src/vip-framework/checks/interestRateModel";
+
+import vip010, { RATE_MODELS, VUSDC_CORE, VUSDT_CORE } from "../../../proposals/arbitrumone/vip-010";
+import VTOKEN_IL_ABI from "./abi/VTokenIL.json";
+
+const ARB_BLOCKS_PER_YEAR = BigNumber.from(31_536_000);
+
+forking(245111060, async () => {
+  const provider = ethers.provider;
+
+  const vUSDCCore = new ethers.Contract(VUSDC_CORE, VTOKEN_IL_ABI, provider);
+  const vUSDTCore = new ethers.Contract(VUSDT_CORE, VTOKEN_IL_ABI, provider);
+
+  describe("Pre-VIP behaviour", async () => {
+    it("has expected interest rate model addresses", async () => {
+      for (const vToken of [vUSDCCore, vUSDTCore]) {
+        expect(await vToken.interestRateModel()).to.equal(
+          RATE_MODELS.JumpRateModelV2_base0bps_slope875bps_jump25000bps_kink8000bps,
+        );
+      }
+    });
+
+    describe("old interest rate model parameters", async () => {
+      checkInterestRate(
+        RATE_MODELS.JumpRateModelV2_base0bps_slope875bps_jump25000bps_kink8000bps,
+        "vUSDT, vUSDC (Core pool)",
+        {
+          base: "0",
+          multiplier: "0.0875",
+          jump: "2.5",
+          kink: "0.8",
+        },
+        ARB_BLOCKS_PER_YEAR,
+      );
+    });
+  });
+
+  describe("Post-VIP behavior", async () => {
+    before(async () => {
+      await pretendExecutingVip(await vip010());
+    });
+
+    it("has the new interest rate model addresses", async () => {
+      for (const vToken of [vUSDCCore, vUSDTCore]) {
+        expect(await vToken.interestRateModel()).to.equal(
+          RATE_MODELS.JumpRateModelV2_base0bps_slope800bps_jump25000bps_kink8000bps,
+        );
+      }
+    });
+
+    describe("new interest rate model parameters", async () => {
+      checkInterestRate(
+        RATE_MODELS.JumpRateModelV2_base0bps_slope800bps_jump25000bps_kink8000bps,
+        "vUSDT, vUSDC (Core pool)",
+        {
+          base: "0",
+          multiplier: "0.08",
+          jump: "2.5",
+          kink: "0.8",
+        },
+        ARB_BLOCKS_PER_YEAR,
+      );
+    });
+  });
+});

--- a/multisig/simulations/ethereum/vip-055/abi/VTokenIL.json
+++ b/multisig/simulations/ethereum/vip-055/abi/VTokenIL.json
@@ -1,0 +1,861 @@
+[
+  { "inputs": [], "stateMutability": "nonpayable", "type": "constructor" },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "actualAddAmount", "type": "uint256" }],
+    "name": "AddReservesFactorFreshCheck",
+    "type": "error"
+  },
+  { "inputs": [], "name": "BorrowCashNotAvailable", "type": "error" },
+  { "inputs": [], "name": "BorrowFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "DelegateNotApproved", "type": "error" },
+  { "inputs": [], "name": "ForceLiquidateBorrowUnauthorized", "type": "error" },
+  { "inputs": [], "name": "HealBorrowUnauthorized", "type": "error" },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "errorCode", "type": "uint256" }],
+    "name": "LiquidateAccrueCollateralInterestFailed",
+    "type": "error"
+  },
+  { "inputs": [], "name": "LiquidateCloseAmountIsUintMax", "type": "error" },
+  { "inputs": [], "name": "LiquidateCloseAmountIsZero", "type": "error" },
+  { "inputs": [], "name": "LiquidateCollateralFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "LiquidateFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "LiquidateLiquidatorIsBorrower", "type": "error" },
+  { "inputs": [], "name": "LiquidateSeizeLiquidatorIsBorrower", "type": "error" },
+  { "inputs": [], "name": "MintFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "ProtocolSeizeShareTooBig", "type": "error" },
+  { "inputs": [], "name": "RedeemFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "RedeemTransferOutNotPossible", "type": "error" },
+  { "inputs": [], "name": "ReduceReservesCashNotAvailable", "type": "error" },
+  { "inputs": [], "name": "ReduceReservesCashValidation", "type": "error" },
+  { "inputs": [], "name": "ReduceReservesFreshCheck", "type": "error" },
+  { "inputs": [], "name": "RepayBorrowFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "SetInterestRateModelFreshCheck", "type": "error" },
+  { "inputs": [], "name": "SetReserveFactorBoundsCheck", "type": "error" },
+  { "inputs": [], "name": "SetReserveFactorFreshCheck", "type": "error" },
+  { "inputs": [], "name": "TransferNotAllowed", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "sender", "type": "address" },
+      { "internalType": "address", "name": "calledContract", "type": "address" },
+      { "internalType": "string", "name": "methodSignature", "type": "string" }
+    ],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  { "inputs": [], "name": "ZeroAddressNotAllowed", "type": "error" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "cashPrior", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "interestAccumulated", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "borrowIndex", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "AccrueInterest",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "spender", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "badDebtDelta", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "badDebtOld", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "badDebtNew", "type": "uint256" }
+    ],
+    "name": "BadDebtIncreased",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "badDebtOld", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "badDebtNew", "type": "uint256" }
+    ],
+    "name": "BadDebtRecovered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "borrowAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBorrows", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "Borrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "payer", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "HealBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "uint8", "name": "version", "type": "uint8" }],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "liquidator", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "indexed": true, "internalType": "address", "name": "vTokenCollateral", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "LiquidateBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "minter", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "mintAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "mintTokens", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBalance", "type": "uint256" }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldAccessControlManager", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newAccessControlManager", "type": "address" }
+    ],
+    "name": "NewAccessControlManager",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract ComptrollerInterface", "name": "oldComptroller", "type": "address" },
+      { "indexed": true, "internalType": "contract ComptrollerInterface", "name": "newComptroller", "type": "address" }
+    ],
+    "name": "NewComptroller",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract InterestRateModel",
+        "name": "oldInterestRateModel",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "contract InterestRateModel",
+        "name": "newInterestRateModel",
+        "type": "address"
+      }
+    ],
+    "name": "NewMarketInterestRateModel",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldProtocolSeizeShareMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newProtocolSeizeShareMantissa", "type": "uint256" }
+    ],
+    "name": "NewProtocolSeizeShare",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "oldProtocolShareReserve", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newProtocolShareReserve", "type": "address" }
+    ],
+    "name": "NewProtocolShareReserve",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldReduceReservesBlockDelta", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newReduceReservesBlockDelta", "type": "uint256" }
+    ],
+    "name": "NewReduceReservesBlockDelta",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldReserveFactorMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newReserveFactorMantissa", "type": "uint256" }
+    ],
+    "name": "NewReserveFactor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "oldShortfall", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newShortfall", "type": "address" }
+    ],
+    "name": "NewShortfallContract",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "ProtocolSeize",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "redeemer", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "redeemAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "redeemTokens", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBalance", "type": "uint256" }
+    ],
+    "name": "Redeem",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "payer", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBorrows", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "RepayBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "benefactor", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "addAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newTotalReserves", "type": "uint256" }
+    ],
+    "name": "ReservesAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "protocolShareReserve", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "reduceAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newTotalReserves", "type": "uint256" }
+    ],
+    "name": "SpreadReservesReduced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": true, "internalType": "address", "name": "token", "type": "address" }],
+    "name": "SweepToken",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "NO_ERROR",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "acceptOwnership", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [],
+    "name": "accessControlManager",
+    "outputs": [{ "internalType": "contract IAccessControlManagerV8", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accrualBlockNumber",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accrueInterest",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "addAmount", "type": "uint256" }],
+    "name": "addReserves",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "badDebt",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "recoveredAmount_", "type": "uint256" }],
+    "name": "badDebtRecovered",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "balanceOfUnderlying",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }],
+    "name": "borrow",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "borrowBalanceCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "borrowBalanceStored",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }
+    ],
+    "name": "borrowBehalf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "borrowIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "borrowRatePerBlock",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "comptroller",
+    "outputs": [{ "internalType": "contract ComptrollerInterface", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "subtractedValue", "type": "uint256" }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "exchangeRateCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "exchangeRateStored",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "internalType": "contract VTokenInterface", "name": "vTokenCollateral", "type": "address" },
+      { "internalType": "bool", "name": "skipLiquidityCheck", "type": "bool" }
+    ],
+    "name": "forceLiquidateBorrow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "getAccountSnapshot",
+    "outputs": [
+      { "internalType": "uint256", "name": "error", "type": "uint256" },
+      { "internalType": "uint256", "name": "vTokenBalance", "type": "uint256" },
+      { "internalType": "uint256", "name": "borrowBalance", "type": "uint256" },
+      { "internalType": "uint256", "name": "exchangeRate", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCash",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "payer", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "healBorrow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "addedValue", "type": "uint256" }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "underlying_", "type": "address" },
+      { "internalType": "contract ComptrollerInterface", "name": "comptroller_", "type": "address" },
+      { "internalType": "contract InterestRateModel", "name": "interestRateModel_", "type": "address" },
+      { "internalType": "uint256", "name": "initialExchangeRateMantissa_", "type": "uint256" },
+      { "internalType": "string", "name": "name_", "type": "string" },
+      { "internalType": "string", "name": "symbol_", "type": "string" },
+      { "internalType": "uint8", "name": "decimals_", "type": "uint8" },
+      { "internalType": "address", "name": "admin_", "type": "address" },
+      { "internalType": "address", "name": "accessControlManager_", "type": "address" },
+      {
+        "components": [
+          { "internalType": "address", "name": "shortfall", "type": "address" },
+          { "internalType": "address payable", "name": "protocolShareReserve", "type": "address" }
+        ],
+        "internalType": "struct VTokenInterface.RiskManagementInit",
+        "name": "riskManagement",
+        "type": "tuple"
+      },
+      { "internalType": "uint256", "name": "reserveFactorMantissa_", "type": "uint256" }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "interestRateModel",
+    "outputs": [{ "internalType": "contract InterestRateModel", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isVToken",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "internalType": "contract VTokenInterface", "name": "vTokenCollateral", "type": "address" }
+    ],
+    "name": "liquidateBorrow",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "mintAmount", "type": "uint256" }],
+    "name": "mint",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "minter", "type": "address" },
+      { "internalType": "uint256", "name": "mintAmount", "type": "uint256" }
+    ],
+    "name": "mintBehalf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolSeizeShareMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolShareReserve",
+    "outputs": [{ "internalType": "address payable", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }],
+    "name": "redeem",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "redeemer", "type": "address" },
+      { "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }
+    ],
+    "name": "redeemBehalf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "redeemAmount", "type": "uint256" }],
+    "name": "redeemUnderlying",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "redeemer", "type": "address" },
+      { "internalType": "uint256", "name": "redeemAmount", "type": "uint256" }
+    ],
+    "name": "redeemUnderlyingBehalf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "reduceAmount", "type": "uint256" }],
+    "name": "reduceReserves",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reduceReservesBlockDelta",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reduceReservesBlockNumber",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "renounceOwnership", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "repayAmount", "type": "uint256" }],
+    "name": "repayBorrow",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "repayBorrowBehalf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserveFactorMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "seize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "accessControlManager_", "type": "address" }],
+    "name": "setAccessControlManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "contract InterestRateModel", "name": "newInterestRateModel", "type": "address" }],
+    "name": "setInterestRateModel",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "newProtocolSeizeShareMantissa_", "type": "uint256" }],
+    "name": "setProtocolSeizeShare",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address payable", "name": "protocolShareReserve_", "type": "address" }],
+    "name": "setProtocolShareReserve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_newReduceReservesBlockDelta", "type": "uint256" }],
+    "name": "setReduceReservesBlockDelta",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "newReserveFactorMantissa", "type": "uint256" }],
+    "name": "setReserveFactor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "shortfall_", "type": "address" }],
+    "name": "setShortfallContract",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "shortfall",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "supplyRatePerBlock",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "contract IERC20Upgradeable", "name": "token", "type": "address" }],
+    "name": "sweepToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalBorrows",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalBorrowsCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalReserves",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "src", "type": "address" },
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "newOwner", "type": "address" }],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "underlying",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/multisig/simulations/ethereum/vip-055/index.ts
+++ b/multisig/simulations/ethereum/vip-055/index.ts
@@ -1,0 +1,113 @@
+import { expect } from "chai";
+import { BigNumber } from "ethers";
+import { ethers } from "hardhat";
+import { forking, pretendExecutingVip } from "src/vip-framework";
+import { checkInterestRate } from "src/vip-framework/checks/interestRateModel";
+
+import vip055, { RATE_MODELS, VCRVUSD_CORE, VDAI_CORE, VTUSD_CORE } from "../../../proposals/ethereum/vip-055";
+import VTOKEN_IL_ABI from "./abi/VTokenIL.json";
+
+const ETH_BLOCKS_PER_YEAR = BigNumber.from(2_628_000);
+
+forking(20575000, async () => {
+  const provider = ethers.provider;
+
+  const vDAICore = new ethers.Contract(VDAI_CORE, VTOKEN_IL_ABI, provider);
+  const vcrvUSDCore = new ethers.Contract(VCRVUSD_CORE, VTOKEN_IL_ABI, provider);
+  const vTUSDCore = new ethers.Contract(VTUSD_CORE, VTOKEN_IL_ABI, provider);
+
+  describe("Pre-VIP behaviour", async () => {
+    it("has expected interest rate model addresses", async () => {
+      expect(await vDAICore.interestRateModel()).to.equal(
+        RATE_MODELS.JumpRateModelV2_base0bps_slope1500bps_jump25000bps_kink8000bps_alternative,
+      );
+      expect(await vcrvUSDCore.interestRateModel()).to.equal(
+        RATE_MODELS.JumpRateModelV2_base0bps_slope875bps_jump25000bps_kink8000bps,
+      );
+      expect(await vTUSDCore.interestRateModel()).to.equal(
+        RATE_MODELS.JumpRateModelV2_base0bps_slope1500bps_jump25000bps_kink8000bps,
+      );
+    });
+
+    describe("old interest rate model parameters", async () => {
+      checkInterestRate(
+        RATE_MODELS.JumpRateModelV2_base0bps_slope1500bps_jump25000bps_kink8000bps_alternative,
+        "vDAI (Core pool)",
+        {
+          base: "0",
+          multiplier: "0.15",
+          jump: "2.5",
+          kink: "0.8",
+        },
+        ETH_BLOCKS_PER_YEAR,
+      );
+
+      checkInterestRate(
+        RATE_MODELS.JumpRateModelV2_base0bps_slope875bps_jump25000bps_kink8000bps,
+        "vcrvUSD (Core pool)",
+        {
+          base: "0",
+          multiplier: "0.0875",
+          jump: "2.5",
+          kink: "0.8",
+        },
+        ETH_BLOCKS_PER_YEAR,
+      );
+
+      checkInterestRate(
+        RATE_MODELS.JumpRateModelV2_base0bps_slope1500bps_jump25000bps_kink8000bps,
+        "vTUSD (Core pool)",
+        {
+          base: "0",
+          multiplier: "0.15",
+          jump: "2.5",
+          kink: "0.8",
+        },
+        ETH_BLOCKS_PER_YEAR,
+      );
+    });
+  });
+
+  describe("Post-VIP behavior", async () => {
+    before(async () => {
+      await pretendExecutingVip(await vip055());
+    });
+
+    it("has the new interest rate model addresses", async () => {
+      for (const vToken of [vDAICore, vTUSDCore]) {
+        expect(await vToken.interestRateModel()).to.equal(
+          RATE_MODELS.JumpRateModelV2_base0bps_slope875bps_jump25000bps_kink8000bps,
+        );
+      }
+      expect(await vcrvUSDCore.interestRateModel()).to.equal(
+        RATE_MODELS.JumpRateModelV2_base0bps_slope1500bps_jump25000bps_kink8000bps,
+      );
+    });
+
+    describe("new interest rate model parameters", async () => {
+      checkInterestRate(
+        RATE_MODELS.JumpRateModelV2_base0bps_slope875bps_jump25000bps_kink8000bps,
+        "vDAI, vTUSD (Core pool)",
+        {
+          base: "0",
+          multiplier: "0.0875",
+          jump: "2.5",
+          kink: "0.8",
+        },
+        ETH_BLOCKS_PER_YEAR,
+      );
+
+      checkInterestRate(
+        RATE_MODELS.JumpRateModelV2_base0bps_slope1500bps_jump25000bps_kink8000bps,
+        "vcrvUSD (Core pool)",
+        {
+          base: "0",
+          multiplier: "0.15",
+          jump: "2.5",
+          kink: "0.8",
+        },
+        ETH_BLOCKS_PER_YEAR,
+      );
+    });
+  });
+});

--- a/simulations/vip-354/abi/VTokenCorePool.json
+++ b/simulations/vip-354/abi/VTokenCorePool.json
@@ -1,0 +1,688 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "underlying_", "type": "address" },
+      { "internalType": "contract ComptrollerInterface", "name": "comptroller_", "type": "address" },
+      { "internalType": "contract InterestRateModel", "name": "interestRateModel_", "type": "address" },
+      { "internalType": "uint256", "name": "initialExchangeRateMantissa_", "type": "uint256" },
+      { "internalType": "string", "name": "name_", "type": "string" },
+      { "internalType": "string", "name": "symbol_", "type": "string" },
+      { "internalType": "uint8", "name": "decimals_", "type": "uint8" },
+      { "internalType": "address payable", "name": "admin_", "type": "address" },
+      { "internalType": "address", "name": "implementation_", "type": "address" },
+      { "internalType": "bytes", "name": "becomeImplementationData", "type": "bytes" }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "cashPrior", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "interestAccumulated", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "borrowIndex", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "AccrueInterest",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "spender", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "borrowAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBorrows", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "Borrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "error", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "info", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "detail", "type": "uint256" }
+    ],
+    "name": "Failure",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "liquidator", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "address", "name": "vTokenCollateral", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "LiquidateBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "minter", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "mintAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "mintTokens", "type": "uint256" }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldAdmin", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newAdmin", "type": "address" }
+    ],
+    "name": "NewAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract ComptrollerInterface",
+        "name": "oldComptroller",
+        "type": "address"
+      },
+      { "indexed": false, "internalType": "contract ComptrollerInterface", "name": "newComptroller", "type": "address" }
+    ],
+    "name": "NewComptroller",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldImplementation", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newImplementation", "type": "address" }
+    ],
+    "name": "NewImplementation",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract InterestRateModel",
+        "name": "oldInterestRateModel",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract InterestRateModel",
+        "name": "newInterestRateModel",
+        "type": "address"
+      }
+    ],
+    "name": "NewMarketInterestRateModel",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldPendingAdmin", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newPendingAdmin", "type": "address" }
+    ],
+    "name": "NewPendingAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldReserveFactorMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newReserveFactorMantissa", "type": "uint256" }
+    ],
+    "name": "NewReserveFactor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "redeemer", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "redeemAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }
+    ],
+    "name": "Redeem",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "payer", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBorrows", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "RepayBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "benefactor", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "addAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newTotalReserves", "type": "uint256" }
+    ],
+    "name": "ReservesAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "admin", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "reduceAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newTotalReserves", "type": "uint256" }
+    ],
+    "name": "ReservesReduced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  { "payable": true, "stateMutability": "payable", "type": "fallback" },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "_acceptAdmin",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "addAmount", "type": "uint256" }],
+    "name": "_addReserves",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "reduceAmount", "type": "uint256" }],
+    "name": "_reduceReserves",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "contract ComptrollerInterface", "name": "newComptroller", "type": "address" }],
+    "name": "_setComptroller",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "implementation_", "type": "address" },
+      { "internalType": "bool", "name": "allowResign", "type": "bool" },
+      { "internalType": "bytes", "name": "becomeImplementationData", "type": "bytes" }
+    ],
+    "name": "_setImplementation",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "contract InterestRateModel", "name": "newInterestRateModel", "type": "address" }],
+    "name": "_setInterestRateModel",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address payable", "name": "newPendingAdmin", "type": "address" }],
+    "name": "_setPendingAdmin",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "newReserveFactorMantissa", "type": "uint256" }],
+    "name": "_setReserveFactor",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "accrualBlockNumber",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "accrueInterest",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "admin",
+    "outputs": [{ "internalType": "address payable", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "balanceOfUnderlying",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }],
+    "name": "borrow",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "borrowBalanceCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "borrowBalanceStored",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "borrowIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "borrowRatePerBlock",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "comptroller",
+    "outputs": [{ "internalType": "contract ComptrollerInterface", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "bytes", "name": "data", "type": "bytes" }],
+    "name": "delegateToImplementation",
+    "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "bytes", "name": "data", "type": "bytes" }],
+    "name": "delegateToViewImplementation",
+    "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "exchangeRateCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "exchangeRateStored",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "getAccountSnapshot",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getCash",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "implementation",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "interestRateModel",
+    "outputs": [{ "internalType": "contract InterestRateModel", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "isVToken",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "internalType": "contract VTokenInterface", "name": "vTokenCollateral", "type": "address" }
+    ],
+    "name": "liquidateBorrow",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "mintAmount", "type": "uint256" }],
+    "name": "mint",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pendingAdmin",
+    "outputs": [{ "internalType": "address payable", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }],
+    "name": "redeem",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "redeemAmount", "type": "uint256" }],
+    "name": "redeemUnderlying",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "uint256", "name": "repayAmount", "type": "uint256" }],
+    "name": "repayBorrow",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "repayBorrowBehalf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "reserveFactorMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "seize",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "supplyRatePerBlock",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalBorrows",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "totalBorrowsCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalReserves",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "src", "type": "address" },
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "underlying",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/simulations/vip-354/abi/VTokenIL.json
+++ b/simulations/vip-354/abi/VTokenIL.json
@@ -1,0 +1,861 @@
+[
+  { "inputs": [], "stateMutability": "nonpayable", "type": "constructor" },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "actualAddAmount", "type": "uint256" }],
+    "name": "AddReservesFactorFreshCheck",
+    "type": "error"
+  },
+  { "inputs": [], "name": "BorrowCashNotAvailable", "type": "error" },
+  { "inputs": [], "name": "BorrowFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "DelegateNotApproved", "type": "error" },
+  { "inputs": [], "name": "ForceLiquidateBorrowUnauthorized", "type": "error" },
+  { "inputs": [], "name": "HealBorrowUnauthorized", "type": "error" },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "errorCode", "type": "uint256" }],
+    "name": "LiquidateAccrueCollateralInterestFailed",
+    "type": "error"
+  },
+  { "inputs": [], "name": "LiquidateCloseAmountIsUintMax", "type": "error" },
+  { "inputs": [], "name": "LiquidateCloseAmountIsZero", "type": "error" },
+  { "inputs": [], "name": "LiquidateCollateralFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "LiquidateFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "LiquidateLiquidatorIsBorrower", "type": "error" },
+  { "inputs": [], "name": "LiquidateSeizeLiquidatorIsBorrower", "type": "error" },
+  { "inputs": [], "name": "MintFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "ProtocolSeizeShareTooBig", "type": "error" },
+  { "inputs": [], "name": "RedeemFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "RedeemTransferOutNotPossible", "type": "error" },
+  { "inputs": [], "name": "ReduceReservesCashNotAvailable", "type": "error" },
+  { "inputs": [], "name": "ReduceReservesCashValidation", "type": "error" },
+  { "inputs": [], "name": "ReduceReservesFreshCheck", "type": "error" },
+  { "inputs": [], "name": "RepayBorrowFreshnessCheck", "type": "error" },
+  { "inputs": [], "name": "SetInterestRateModelFreshCheck", "type": "error" },
+  { "inputs": [], "name": "SetReserveFactorBoundsCheck", "type": "error" },
+  { "inputs": [], "name": "SetReserveFactorFreshCheck", "type": "error" },
+  { "inputs": [], "name": "TransferNotAllowed", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "sender", "type": "address" },
+      { "internalType": "address", "name": "calledContract", "type": "address" },
+      { "internalType": "string", "name": "methodSignature", "type": "string" }
+    ],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  { "inputs": [], "name": "ZeroAddressNotAllowed", "type": "error" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "cashPrior", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "interestAccumulated", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "borrowIndex", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "AccrueInterest",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "spender", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "badDebtDelta", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "badDebtOld", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "badDebtNew", "type": "uint256" }
+    ],
+    "name": "BadDebtIncreased",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "badDebtOld", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "badDebtNew", "type": "uint256" }
+    ],
+    "name": "BadDebtRecovered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "borrowAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBorrows", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "Borrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "payer", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "HealBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "uint8", "name": "version", "type": "uint8" }],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "liquidator", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "indexed": true, "internalType": "address", "name": "vTokenCollateral", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "LiquidateBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "minter", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "mintAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "mintTokens", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBalance", "type": "uint256" }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldAccessControlManager", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newAccessControlManager", "type": "address" }
+    ],
+    "name": "NewAccessControlManager",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "contract ComptrollerInterface", "name": "oldComptroller", "type": "address" },
+      { "indexed": true, "internalType": "contract ComptrollerInterface", "name": "newComptroller", "type": "address" }
+    ],
+    "name": "NewComptroller",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract InterestRateModel",
+        "name": "oldInterestRateModel",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "contract InterestRateModel",
+        "name": "newInterestRateModel",
+        "type": "address"
+      }
+    ],
+    "name": "NewMarketInterestRateModel",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldProtocolSeizeShareMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newProtocolSeizeShareMantissa", "type": "uint256" }
+    ],
+    "name": "NewProtocolSeizeShare",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "oldProtocolShareReserve", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newProtocolShareReserve", "type": "address" }
+    ],
+    "name": "NewProtocolShareReserve",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldReduceReservesBlockDelta", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newReduceReservesBlockDelta", "type": "uint256" }
+    ],
+    "name": "NewReduceReservesBlockDelta",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldReserveFactorMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newReserveFactorMantissa", "type": "uint256" }
+    ],
+    "name": "NewReserveFactor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "oldShortfall", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newShortfall", "type": "address" }
+    ],
+    "name": "NewShortfallContract",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "ProtocolSeize",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "redeemer", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "redeemAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "redeemTokens", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBalance", "type": "uint256" }
+    ],
+    "name": "Redeem",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "payer", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBorrows", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "RepayBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "benefactor", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "addAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newTotalReserves", "type": "uint256" }
+    ],
+    "name": "ReservesAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "protocolShareReserve", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "reduceAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newTotalReserves", "type": "uint256" }
+    ],
+    "name": "SpreadReservesReduced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": true, "internalType": "address", "name": "token", "type": "address" }],
+    "name": "SweepToken",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "NO_ERROR",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "acceptOwnership", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [],
+    "name": "accessControlManager",
+    "outputs": [{ "internalType": "contract IAccessControlManagerV8", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accrualBlockNumber",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accrueInterest",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "addAmount", "type": "uint256" }],
+    "name": "addReserves",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "badDebt",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "recoveredAmount_", "type": "uint256" }],
+    "name": "badDebtRecovered",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "balanceOfUnderlying",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }],
+    "name": "borrow",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "borrowBalanceCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "borrowBalanceStored",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }
+    ],
+    "name": "borrowBehalf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "borrowIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "borrowRatePerBlock",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "comptroller",
+    "outputs": [{ "internalType": "contract ComptrollerInterface", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "subtractedValue", "type": "uint256" }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "exchangeRateCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "exchangeRateStored",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "internalType": "contract VTokenInterface", "name": "vTokenCollateral", "type": "address" },
+      { "internalType": "bool", "name": "skipLiquidityCheck", "type": "bool" }
+    ],
+    "name": "forceLiquidateBorrow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "getAccountSnapshot",
+    "outputs": [
+      { "internalType": "uint256", "name": "error", "type": "uint256" },
+      { "internalType": "uint256", "name": "vTokenBalance", "type": "uint256" },
+      { "internalType": "uint256", "name": "borrowBalance", "type": "uint256" },
+      { "internalType": "uint256", "name": "exchangeRate", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCash",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "payer", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "healBorrow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "addedValue", "type": "uint256" }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "underlying_", "type": "address" },
+      { "internalType": "contract ComptrollerInterface", "name": "comptroller_", "type": "address" },
+      { "internalType": "contract InterestRateModel", "name": "interestRateModel_", "type": "address" },
+      { "internalType": "uint256", "name": "initialExchangeRateMantissa_", "type": "uint256" },
+      { "internalType": "string", "name": "name_", "type": "string" },
+      { "internalType": "string", "name": "symbol_", "type": "string" },
+      { "internalType": "uint8", "name": "decimals_", "type": "uint8" },
+      { "internalType": "address", "name": "admin_", "type": "address" },
+      { "internalType": "address", "name": "accessControlManager_", "type": "address" },
+      {
+        "components": [
+          { "internalType": "address", "name": "shortfall", "type": "address" },
+          { "internalType": "address payable", "name": "protocolShareReserve", "type": "address" }
+        ],
+        "internalType": "struct VTokenInterface.RiskManagementInit",
+        "name": "riskManagement",
+        "type": "tuple"
+      },
+      { "internalType": "uint256", "name": "reserveFactorMantissa_", "type": "uint256" }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "interestRateModel",
+    "outputs": [{ "internalType": "contract InterestRateModel", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isVToken",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "internalType": "contract VTokenInterface", "name": "vTokenCollateral", "type": "address" }
+    ],
+    "name": "liquidateBorrow",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "mintAmount", "type": "uint256" }],
+    "name": "mint",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "minter", "type": "address" },
+      { "internalType": "uint256", "name": "mintAmount", "type": "uint256" }
+    ],
+    "name": "mintBehalf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolSeizeShareMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolShareReserve",
+    "outputs": [{ "internalType": "address payable", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }],
+    "name": "redeem",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "redeemer", "type": "address" },
+      { "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }
+    ],
+    "name": "redeemBehalf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "redeemAmount", "type": "uint256" }],
+    "name": "redeemUnderlying",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "redeemer", "type": "address" },
+      { "internalType": "uint256", "name": "redeemAmount", "type": "uint256" }
+    ],
+    "name": "redeemUnderlyingBehalf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "reduceAmount", "type": "uint256" }],
+    "name": "reduceReserves",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reduceReservesBlockDelta",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reduceReservesBlockNumber",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "renounceOwnership", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "repayAmount", "type": "uint256" }],
+    "name": "repayBorrow",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "repayBorrowBehalf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserveFactorMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "seize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "accessControlManager_", "type": "address" }],
+    "name": "setAccessControlManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "contract InterestRateModel", "name": "newInterestRateModel", "type": "address" }],
+    "name": "setInterestRateModel",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "newProtocolSeizeShareMantissa_", "type": "uint256" }],
+    "name": "setProtocolSeizeShare",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address payable", "name": "protocolShareReserve_", "type": "address" }],
+    "name": "setProtocolShareReserve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_newReduceReservesBlockDelta", "type": "uint256" }],
+    "name": "setReduceReservesBlockDelta",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "newReserveFactorMantissa", "type": "uint256" }],
+    "name": "setReserveFactor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "shortfall_", "type": "address" }],
+    "name": "setShortfallContract",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "shortfall",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "supplyRatePerBlock",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "contract IERC20Upgradeable", "name": "token", "type": "address" }],
+    "name": "sweepToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalBorrows",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalBorrowsCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalReserves",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "src", "type": "address" },
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "newOwner", "type": "address" }],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "underlying",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/simulations/vip-354/bscmainnet.ts
+++ b/simulations/vip-354/bscmainnet.ts
@@ -1,0 +1,165 @@
+import { TransactionResponse } from "@ethersproject/providers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { expectEvents } from "src/utils";
+import { forking, testVip } from "src/vip-framework";
+import { checkInterestRate } from "src/vip-framework/checks/interestRateModel";
+
+import vip354, {
+  RATE_MODELS,
+  VDAI_CORE,
+  VFDUSD_CORE,
+  VUSDC_CORE,
+  VUSDT_CORE,
+  VUSDT_DEFI,
+  VUSDT_GAMEFI,
+  VUSDT_STABLECOINS,
+} from "../../vips/vip-354/bscmainnet";
+import VTOKEN_CORE_POOL_ABI from "./abi/VTokenCorePool.json";
+import VTOKEN_IL_ABI from "./abi/VTokenIL.json";
+
+forking(41557364, async () => {
+  const provider = ethers.provider;
+
+  const vUSDTCore = new ethers.Contract(VUSDT_CORE, VTOKEN_CORE_POOL_ABI, provider);
+  const vUSDCCore = new ethers.Contract(VUSDC_CORE, VTOKEN_CORE_POOL_ABI, provider);
+  const vDAICore = new ethers.Contract(VDAI_CORE, VTOKEN_CORE_POOL_ABI, provider);
+  const vFDUSDCore = new ethers.Contract(VFDUSD_CORE, VTOKEN_CORE_POOL_ABI, provider);
+
+  const vUSDTStablecoins = new ethers.Contract(VUSDT_STABLECOINS, VTOKEN_IL_ABI, provider);
+  const vUSDTGameFi = new ethers.Contract(VUSDT_GAMEFI, VTOKEN_IL_ABI, provider);
+  const vUSDTDeFi = new ethers.Contract(VUSDT_DEFI, VTOKEN_IL_ABI, provider);
+
+  describe("Pre-VIP behaviour", async () => {
+    it("has expected interest rate model addresses", async () => {
+      for (const vToken of [vUSDTCore, vUSDCCore, vDAICore]) {
+        expect(await vToken.interestRateModel()).to.equal(
+          RATE_MODELS.JumpRateModel_base0bps_slope875bps_jump25000bps_kink8000bps,
+        );
+      }
+      expect(await vFDUSDCore.interestRateModel()).to.equal(
+        RATE_MODELS.JumpRateModel_base0bps_slope875bps_jump50000bps_kink8000bps,
+      );
+      expect(await vUSDTStablecoins.interestRateModel()).to.equal(
+        RATE_MODELS.JumpRateModelV2_base0bps_slope1000bps_jump25000bps_kink8000bps,
+      );
+      for (const vToken of [vUSDTGameFi, vUSDTDeFi]) {
+        expect(await vToken.interestRateModel()).to.equal(
+          RATE_MODELS.JumpRateModelV2_base200bps_slope1500bps_jump25000bps_kink8000bps,
+        );
+      }
+    });
+
+    describe("old interest rate model parameters", async () => {
+      checkInterestRate(
+        RATE_MODELS.JumpRateModel_base0bps_slope875bps_jump25000bps_kink8000bps,
+        "vUSDT, vUSDC, vDAI (Core pool)",
+        {
+          base: "0",
+          multiplier: "0.0875",
+          jump: "2.5",
+          kink: "0.8",
+        },
+      );
+
+      checkInterestRate(RATE_MODELS.JumpRateModel_base0bps_slope875bps_jump50000bps_kink8000bps, "vFDUSD (Core pool)", {
+        base: "0",
+        multiplier: "0.0875",
+        jump: "5",
+        kink: "0.8",
+      });
+
+      checkInterestRate(
+        RATE_MODELS.JumpRateModelV2_base0bps_slope1000bps_jump25000bps_kink8000bps,
+        "vUSDT (Stablecoins pool)",
+        {
+          base: "0",
+          multiplier: "0.1",
+          jump: "2.5",
+          kink: "0.8",
+        },
+      );
+
+      checkInterestRate(
+        RATE_MODELS.JumpRateModelV2_base200bps_slope1500bps_jump25000bps_kink8000bps,
+        "vUSDT (GameFi, DeFi pools)",
+        {
+          base: "0.02",
+          multiplier: "0.15",
+          jump: "2.5",
+          kink: "0.8",
+        },
+      );
+    });
+  });
+
+  testVip("VIP-354", await vip354(), {
+    callbackAfterExecution: async (txResponse: TransactionResponse) => {
+      await expectEvents(txResponse, [VTOKEN_CORE_POOL_ABI], ["NewMarketInterestRateModel"], [4]);
+      await expectEvents(txResponse, [VTOKEN_IL_ABI], ["NewMarketInterestRateModel"], [3]);
+    },
+  });
+
+  describe("Post-VIP behavior", async () => {
+    it("has the new interest rate model addresses", async () => {
+      for (const vToken of [vUSDTCore, vUSDCCore, vDAICore]) {
+        expect(await vToken.interestRateModel()).to.equal(
+          RATE_MODELS.JumpRateModel_base0bps_slope1000bps_jump25000bps_kink8000bps,
+        );
+      }
+      expect(await vFDUSDCore.interestRateModel()).to.equal(
+        RATE_MODELS.JumpRateModel_base0bps_slope750bps_jump50000bps_kink8000bps,
+      );
+      expect(await vUSDTStablecoins.interestRateModel()).to.equal(
+        RATE_MODELS.JumpRateModelV2_base0bps_slope375bps_jump25000bps_kink8000bps,
+      );
+      for (const vToken of [vUSDTGameFi, vUSDTDeFi]) {
+        expect(await vToken.interestRateModel()).to.equal(
+          RATE_MODELS.JumpRateModelV2_base200bps_slope1350bps_jump25000bps_kink8000bps,
+        );
+      }
+    });
+
+    describe("new interest rate model parameters", async () => {
+      checkInterestRate(
+        RATE_MODELS.JumpRateModel_base0bps_slope1000bps_jump25000bps_kink8000bps,
+        "vUSDT, vUSDC, vDAI (Core pool)",
+        {
+          base: "0",
+          multiplier: "0.1",
+          jump: "2.5",
+          kink: "0.8",
+        },
+      );
+
+      checkInterestRate(RATE_MODELS.JumpRateModel_base0bps_slope750bps_jump50000bps_kink8000bps, "vFDUSD (Core pool)", {
+        base: "0",
+        multiplier: "0.075",
+        jump: "5",
+        kink: "0.8",
+      });
+
+      checkInterestRate(
+        RATE_MODELS.JumpRateModelV2_base0bps_slope375bps_jump25000bps_kink8000bps,
+        "vUSDT (Stablecoins pool)",
+        {
+          base: "0",
+          multiplier: "0.0375",
+          jump: "2.5",
+          kink: "0.8",
+        },
+      );
+
+      checkInterestRate(
+        RATE_MODELS.JumpRateModelV2_base200bps_slope1350bps_jump25000bps_kink8000bps,
+        "vUSDT (GameFi, DeFi pools)",
+        {
+          base: "0.02",
+          multiplier: "0.135",
+          jump: "2.5",
+          kink: "0.8",
+        },
+      );
+    });
+  });
+});

--- a/vips/vip-354/bscmainnet.ts
+++ b/vips/vip-354/bscmainnet.ts
@@ -1,0 +1,82 @@
+import { ProposalType } from "src/types";
+import { makeProposal } from "src/utils";
+
+export const VUSDT_CORE = "0xfD5840Cd36d94D7229439859C0112a4185BC0255";
+export const VUSDC_CORE = "0xecA88125a5ADbe82614ffC12D0DB554E2e2867C8";
+export const VDAI_CORE = "0x334b3eCB4DCa3593BCCC3c7EBD1A1C1d1780FBF1";
+export const VFDUSD_CORE = "0xC4eF4229FEc74Ccfe17B2bdeF7715fAC740BA0ba";
+export const VUSDT_STABLECOINS = "0x5e3072305F9caE1c7A82F6Fe9E38811c74922c3B";
+export const VUSDT_GAMEFI = "0x4978591f17670A846137d9d613e333C38dc68A37";
+export const VUSDT_DEFI = "0x1D8bBDE12B6b34140604E18e9f9c6e14deC16854";
+
+export const RATE_MODELS = {
+  JumpRateModel_base0bps_slope875bps_jump25000bps_kink8000bps: "0xBe4609d972FdEBAa9DC870F4A957F40C301bEb1D",
+  JumpRateModel_base0bps_slope875bps_jump50000bps_kink8000bps: "0xE19C14171C2aC6CA63E008133e4B0D8571164BA3",
+  JumpRateModelV2_base0bps_slope1000bps_jump25000bps_kink8000bps: "0x2ba0F45f7368d2A56d0c9e5a29af363987BE1d02",
+  JumpRateModelV2_base200bps_slope1500bps_jump25000bps_kink8000bps: "0x5ECa0FBBc5e7bf49dbFb1953a92784F8e4248eF6",
+
+  JumpRateModel_base0bps_slope1000bps_jump25000bps_kink8000bps: "0x62A8919C4C413fd4F9aef7348540Bc4B1b5CC805",
+  JumpRateModel_base0bps_slope750bps_jump50000bps_kink8000bps: "0xdEf4b9462223c9a44E61d217a145063C7836FD7B",
+  JumpRateModelV2_base0bps_slope375bps_jump25000bps_kink8000bps: "0xb36b273601Ac5e0CaBD0845b7B8caa3426611Ca0",
+  JumpRateModelV2_base200bps_slope1350bps_jump25000bps_kink8000bps: "0x3aB2e4594D9C81455b330B423Dec61E49EB11667",
+};
+
+const vip354 = () => {
+  const meta = {
+    version: "v2",
+    title: "VIP-354 Risk Parameters Adjustments (Stablecoins)",
+    description: `If passed, this VIP will perform the changes recommended by Chaos Labs in this Venus community forum publication: [Chaos Labs - Interest Rate Curve Amendment for Stablecoins on Venus](https://community.venus.io/t/chaos-labs-interest-rate-curve-amendment-for-stablecoins-on-venus/4531).
+
+* BNB chain
+    * Increase multiplier (annualized), from 0.0875 (7% APR at kink) to 0.1 (8% APR at kink): [USDT (Core pool)](https://bscscan.com/address/0xfD5840Cd36d94D7229439859C0112a4185BC0255), [USDC (Core pool)](https://bscscan.com/address/0xecA88125a5ADbe82614ffC12D0DB554E2e2867C8) and [DAI (Core pool)](https://bscscan.com/address/0x334b3eCB4DCa3593BCCC3c7EBD1A1C1d1780FBF1),
+    * Decrease multiplier (annualized), from 0.0875 (7% APR at kink) to 0.075 (6% APR at kink): [FDUSD (Core pool)](https://bscscan.com/address/0xC4eF4229FEc74Ccfe17B2bdeF7715fAC740BA0ba)
+    * Decrease multiplier (annualized), from 0.1 (8% APR at kink) to 0.0375 (3% APR at kink): [USDT (Stablecoins)](https://bscscan.com/address/0x5e3072305F9caE1c7A82F6Fe9E38811c74922c3B)
+    * Decrease multiplier (annualized), from 0.15 (12% APR at kink) to 0.135 (10.8% APR at kink): [USDT (GameFi)](https://bscscan.com/address/0x4978591f17670A846137d9d613e333C38dc68A37), [USDT (DeFi)](https://bscscan.com/address/0x1D8bBDE12B6b34140604E18e9f9c6e14deC16854)
+* Ethereum
+    * Increase multiplier (annualized), from 0.0875 (7% APR at kink) to 0.15 (12% APR at kink): [crvUSD (Core pool)](https://etherscan.io/address/0x672208C10aaAA2F9A6719F449C4C8227bc0BC202)
+    * Decrease multiplier (annualized), from 0.15 (12% APR at kink) to 0.0875 (7% APR at kink): [DAI (Core pool)](https://etherscan.io/address/0xd8AdD9B41D4E1cd64Edad8722AB0bA8D35536657) and [TUSD (Core pool)](https://etherscan.io/address/0x13eB80FDBe5C5f4a7039728E258A6f05fb3B912b)
+* Arbitrum one
+    * Decrease multiplier (annualized), from 0.0875 (7% APR at kink) to 0.08 (6.4% APR at kink): [USDC (Core pool)](https://arbiscan.io/address/0x7D8609f8da70fF9027E9bc5229Af4F6727662707), [USDT (Core pool)](https://arbiscan.io/address/0xB9F9117d4200dC296F9AcD1e8bE1937df834a2fD)
+
+Complete analysis and details of these recommendations are available in the above publications.
+
+VIP simulation: [https://github.com/VenusProtocol/vips/pull/359](https://github.com/VenusProtocol/vips/pull/359)
+
+**Disclaimer for Ethereum and Arbitrum one commands**
+
+Privilege commands on Ethereum and opBNB will be executed by the Guardian wallets ([Ethereum](https://etherscan.io/address/0x285960C5B22fD66A736C7136967A3eB15e93CC67), [Arbitrum one](https://arbiscan.io/address/0x14e0e151b33f9802b3e75b621c1457afc44dcaa0)), until the [Multichain Governance](https://docs-v4.venus.io/technical-reference/reference-technical-articles/multichain-governance) contracts are fully enabled. If this VIP passes, [this](https://app.safe.global/transactions/tx?safe=eth:0x285960C5B22fD66A736C7136967A3eB15e93CC67&id=multisig_0x285960C5B22fD66A736C7136967A3eB15e93CC67_0x5672182a533c441cbc4537c21728e354dbd8764ef36f8d171f8704502040b070) and [this](https://app.safe.global/transactions/tx?safe=arb1:0x14e0E151b33f9802b3e75b621c1457afc44DcAA0&id=multisig_0x14e0E151b33f9802b3e75b621c1457afc44DcAA0_0x1ddcc5cd0f5f797cee550ed845be65545b9af4e701642a1eed1c0998f08dc0b7) multisig transactions will be executed. Otherwise, they will be rejected.
+`,
+    forDescription: "I agree that Venus Protocol should proceed with this proposal",
+    againstDescription: "I do not think that Venus Protocol should proceed with this proposal",
+    abstainDescription: "I am indifferent to whether Venus Protocol proceeds or not",
+  };
+
+  return makeProposal(
+    [
+      ...[VUSDT_CORE, VUSDC_CORE, VDAI_CORE].map((vToken: string) => ({
+        target: vToken,
+        signature: "_setInterestRateModel(address)",
+        params: [RATE_MODELS.JumpRateModel_base0bps_slope1000bps_jump25000bps_kink8000bps],
+      })),
+      {
+        target: VFDUSD_CORE,
+        signature: "_setInterestRateModel(address)",
+        params: [RATE_MODELS.JumpRateModel_base0bps_slope750bps_jump50000bps_kink8000bps],
+      },
+      {
+        target: VUSDT_STABLECOINS,
+        signature: "setInterestRateModel(address)",
+        params: [RATE_MODELS.JumpRateModelV2_base0bps_slope375bps_jump25000bps_kink8000bps],
+      },
+      ...[VUSDT_GAMEFI, VUSDT_DEFI].map((vToken: string) => ({
+        target: vToken,
+        signature: "setInterestRateModel(address)",
+        params: [RATE_MODELS.JumpRateModelV2_base200bps_slope1350bps_jump25000bps_kink8000bps],
+      })),
+    ],
+    meta,
+    ProposalType.FAST_TRACK,
+  );
+};
+
+export default vip354;


### PR DESCRIPTION
https://community.venus.io/t/chaos-labs-interest-rate-curve-amendment-for-stablecoins-on-venus/4531

Note: Contrary to what's written in the proposal, the multiplier for crvUSD_Core on Ethereum is currently set to 0.0875, not 0.1250