### PR TITLE
[VPD-995]:  VIP for SolvBTC oracle update, U oracle update, and XVS base reward grant on BNB Chain

### DIFF
--- a/simulations/vip-612/abi/CoreComptroller.json
+++ b/simulations/vip-612/abi/CoreComptroller.json
@@ -1,0 +1,1147 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract VToken",
+        "name": "vToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "borrower",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "venusDelta",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "venusBorrowIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "DistributedBorrowerVenus",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract VToken",
+        "name": "vToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "supplier",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "venusDelta",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "venusSupplyIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "DistributedSupplierVenus",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "DistributedVAIVaultVenus",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "error",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "info",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "detail",
+        "type": "uint256"
+      }
+    ],
+    "name": "Failure",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract VToken",
+        "name": "vToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "MarketEntered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "VenusGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "holder",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "VenusSeized",
+    "type": "event"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "_grantXVS",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "accountAssets",
+    "outputs": [
+      {
+        "internalType": "contract VToken",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "market",
+        "type": "address"
+      },
+      {
+        "internalType": "enum ComptrollerTypes.Action",
+        "name": "action",
+        "type": "uint8"
+      }
+    ],
+    "name": "actionPaused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "admin",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "allMarkets",
+    "outputs": [
+      {
+        "internalType": "contract VToken",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "approvedDelegates",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "borrowCapGuardian",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "borrowCaps",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "holders",
+        "type": "address[]"
+      },
+      {
+        "internalType": "contract VToken[]",
+        "name": "vTokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "bool",
+        "name": "borrowers",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "suppliers",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "collateral",
+        "type": "bool"
+      }
+    ],
+    "name": "claimVenus",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "holder",
+        "type": "address"
+      },
+      {
+        "internalType": "contract VToken[]",
+        "name": "vTokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "claimVenus",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "holder",
+        "type": "address"
+      }
+    ],
+    "name": "claimVenus",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "holders",
+        "type": "address[]"
+      },
+      {
+        "internalType": "contract VToken[]",
+        "name": "vTokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "bool",
+        "name": "borrowers",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "suppliers",
+        "type": "bool"
+      }
+    ],
+    "name": "claimVenus",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "holder",
+        "type": "address"
+      }
+    ],
+    "name": "claimVenusAsCollateral",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "closeFactorMantissa",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "comptrollerImplementation",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "comptrollerLens",
+    "outputs": [
+      {
+        "internalType": "contract ComptrollerLensInterface",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getXVSAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getXVSVTokenAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "isForcedLiquidationEnabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "isForcedLiquidationEnabledForUser",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "liquidationIncentiveMantissa",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "liquidatorContract",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "markets",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isListed",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collateralFactorMantissa",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isVenus",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "maxAssets",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "minReleaseAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "mintVAIGuardianPaused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "mintedVAIs",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "oracle",
+    "outputs": [
+      {
+        "internalType": "contract PriceOracle",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pauseGuardian",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pendingAdmin",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pendingComptrollerImplementation",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "prime",
+    "outputs": [
+      {
+        "internalType": "contract IPrime",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "protocolPaused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "releaseStartBlock",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "repayVAIGuardianPaused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "holders",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      }
+    ],
+    "name": "seizeVenus",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "supplyCaps",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "treasuryAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "treasuryGuardian",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "treasuryPercent",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "vaiController",
+    "outputs": [
+      {
+        "internalType": "contract VAIControllerInterface",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "vaiMintRate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "vaiVaultAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "venusAccrued",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "venusBorrowSpeeds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "venusBorrowState",
+    "outputs": [
+      {
+        "internalType": "uint224",
+        "name": "index",
+        "type": "uint224"
+      },
+      {
+        "internalType": "uint32",
+        "name": "block",
+        "type": "uint32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "venusBorrowerIndex",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "venusInitialIndex",
+    "outputs": [
+      {
+        "internalType": "uint224",
+        "name": "",
+        "type": "uint224"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "venusSupplierIndex",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "venusSupplySpeeds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "venusSupplyState",
+    "outputs": [
+      {
+        "internalType": "uint224",
+        "name": "index",
+        "type": "uint224"
+      },
+      {
+        "internalType": "uint32",
+        "name": "block",
+        "type": "uint32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "venusVAIVaultRate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/simulations/vip-612/abi/XVS.json
+++ b/simulations/vip-612/abi/XVS.json
@@ -1,0 +1,318 @@
+[
+  {
+    "inputs": [{ "internalType": "address", "name": "accessControlManager_", "type": "address" }],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "user", "type": "address" }],
+    "name": "AccountBlacklisted",
+    "type": "error"
+  },
+  { "inputs": [], "name": "AddressesMustDiffer", "type": "error" },
+  { "inputs": [], "name": "MintLimitExceed", "type": "error" },
+  { "inputs": [], "name": "MintedAmountExceed", "type": "error" },
+  { "inputs": [], "name": "NewCapNotGreaterThanMintedTokens", "type": "error" },
+  { "inputs": [], "name": "Unauthorized", "type": "error" },
+  { "inputs": [], "name": "ZeroAddressNotAllowed", "type": "error" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "spender", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
+      { "indexed": false, "internalType": "bool", "name": "value", "type": "bool" }
+    ],
+    "name": "BlacklistUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "minter", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "MintCapChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "minter", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "newLimit", "type": "uint256" }
+    ],
+    "name": "MintLimitDecreased",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "minter", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "newLimit", "type": "uint256" }
+    ],
+    "name": "MintLimitIncreased",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "source", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "destination", "type": "address" }
+    ],
+    "name": "MintedTokensMigrated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "oldAccessControlManager", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newAccessControlManager", "type": "address" }
+    ],
+    "name": "NewAccessControlManager",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "address", "name": "account", "type": "address" }],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "address", "name": "account", "type": "address" }],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "accessControlManager",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account_", "type": "address" },
+      { "internalType": "uint256", "name": "amount_", "type": "uint256" }
+    ],
+    "name": "burn",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "subtractedValue", "type": "uint256" }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "addedValue", "type": "uint256" }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "user_", "type": "address" }],
+    "name": "isBlackListed",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "source_", "type": "address" },
+      { "internalType": "address", "name": "destination_", "type": "address" }
+    ],
+    "name": "migrateMinterTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account_", "type": "address" },
+      { "internalType": "uint256", "name": "amount_", "type": "uint256" }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "minterToCap",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "minterToMintedAmount",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "pause", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "renounceOwnership", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [{ "internalType": "address", "name": "newAccessControlAddress_", "type": "address" }],
+    "name": "setAccessControlManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "minter_", "type": "address" },
+      { "internalType": "uint256", "name": "amount_", "type": "uint256" }
+    ],
+    "name": "setMintCap",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "newOwner", "type": "address" }],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "inputs": [], "name": "unpause", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user_", "type": "address" },
+      { "internalType": "bool", "name": "value_", "type": "bool" }
+    ],
+    "name": "updateBlacklist",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/simulations/vip-612/abi/accessControlManager.json
+++ b/simulations/vip-612/abi/accessControlManager.json
@@ -1,0 +1,23 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "contractAddress", "type": "address" },
+      { "internalType": "string", "name": "functionSig", "type": "string" },
+      { "internalType": "address", "name": "accountToPermit", "type": "address" }
+    ],
+    "name": "giveCallPermission",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "hasRole",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/simulations/vip-612/abi/boundValidator.json
+++ b/simulations/vip-612/abi/boundValidator.json
@@ -1,0 +1,13 @@
+[
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "validateConfigs",
+    "outputs": [
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "upperBoundRatio", "type": "uint256" },
+      { "internalType": "uint256", "name": "lowerBoundRatio", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/simulations/vip-612/abi/chainlinkOracle.json
+++ b/simulations/vip-612/abi/chainlinkOracle.json
@@ -1,0 +1,187 @@
+[
+  { "inputs": [], "stateMutability": "nonpayable", "type": "constructor" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "sender", "type": "address" },
+      { "internalType": "address", "name": "calledContract", "type": "address" },
+      { "internalType": "string", "name": "methodSignature", "type": "string" }
+    ],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "uint8", "name": "version", "type": "uint8" }],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldAccessControlManager", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newAccessControlManager", "type": "address" }
+    ],
+    "name": "NewAccessControlManager",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "asset", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "previousPriceMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newPriceMantissa", "type": "uint256" }
+    ],
+    "name": "PricePosted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "asset", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "feed", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "maxStalePeriod", "type": "uint256" }
+    ],
+    "name": "TokenConfigAdded",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "NATIVE_TOKEN_ADDR",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "acceptOwnership", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [],
+    "name": "accessControlManager",
+    "outputs": [{ "internalType": "contract IAccessControlManagerV8", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "asset", "type": "address" }],
+    "name": "getPrice",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "accessControlManager_", "type": "address" }],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "prices",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "renounceOwnership", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [{ "internalType": "address", "name": "accessControlManager_", "type": "address" }],
+    "name": "setAccessControlManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "price", "type": "uint256" }
+    ],
+    "name": "setDirectPrice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "asset", "type": "address" },
+          { "internalType": "address", "name": "feed", "type": "address" },
+          { "internalType": "uint256", "name": "maxStalePeriod", "type": "uint256" }
+        ],
+        "internalType": "struct ChainlinkOracle.TokenConfig",
+        "name": "tokenConfig",
+        "type": "tuple"
+      }
+    ],
+    "name": "setTokenConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "asset", "type": "address" },
+          { "internalType": "address", "name": "feed", "type": "address" },
+          { "internalType": "uint256", "name": "maxStalePeriod", "type": "uint256" }
+        ],
+        "internalType": "struct ChainlinkOracle.TokenConfig[]",
+        "name": "tokenConfigs_",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "setTokenConfigs",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "tokenConfigs",
+    "outputs": [
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "address", "name": "feed", "type": "address" },
+      { "internalType": "uint256", "name": "maxStalePeriod", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "newOwner", "type": "address" }],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/simulations/vip-612/abi/redstoneOracle.json
+++ b/simulations/vip-612/abi/redstoneOracle.json
@@ -1,0 +1,187 @@
+[
+  { "inputs": [], "stateMutability": "nonpayable", "type": "constructor" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "sender", "type": "address" },
+      { "internalType": "address", "name": "calledContract", "type": "address" },
+      { "internalType": "string", "name": "methodSignature", "type": "string" }
+    ],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "uint8", "name": "version", "type": "uint8" }],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldAccessControlManager", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newAccessControlManager", "type": "address" }
+    ],
+    "name": "NewAccessControlManager",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "asset", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "previousPriceMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newPriceMantissa", "type": "uint256" }
+    ],
+    "name": "PricePosted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "asset", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "feed", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "maxStalePeriod", "type": "uint256" }
+    ],
+    "name": "TokenConfigAdded",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "NATIVE_TOKEN_ADDR",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "acceptOwnership", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [],
+    "name": "accessControlManager",
+    "outputs": [{ "internalType": "contract IAccessControlManagerV8", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "asset", "type": "address" }],
+    "name": "getPrice",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "accessControlManager_", "type": "address" }],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "prices",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "renounceOwnership", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [{ "internalType": "address", "name": "accessControlManager_", "type": "address" }],
+    "name": "setAccessControlManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "price", "type": "uint256" }
+    ],
+    "name": "setDirectPrice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "asset", "type": "address" },
+          { "internalType": "address", "name": "feed", "type": "address" },
+          { "internalType": "uint256", "name": "maxStalePeriod", "type": "uint256" }
+        ],
+        "internalType": "struct ChainlinkOracle.TokenConfig",
+        "name": "tokenConfig",
+        "type": "tuple"
+      }
+    ],
+    "name": "setTokenConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "asset", "type": "address" },
+          { "internalType": "address", "name": "feed", "type": "address" },
+          { "internalType": "uint256", "name": "maxStalePeriod", "type": "uint256" }
+        ],
+        "internalType": "struct ChainlinkOracle.TokenConfig[]",
+        "name": "tokenConfigs_",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "setTokenConfigs",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "tokenConfigs",
+    "outputs": [
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "address", "name": "feed", "type": "address" },
+      { "internalType": "uint256", "name": "maxStalePeriod", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "newOwner", "type": "address" }],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/simulations/vip-612/abi/resilientOracle.json
+++ b/simulations/vip-612/abi/resilientOracle.json
@@ -1,0 +1,320 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "nativeMarketAddress", "type": "address" },
+      { "internalType": "address", "name": "vaiAddress", "type": "address" },
+      { "internalType": "contract BoundValidatorInterface", "name": "_boundValidator", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "sender", "type": "address" },
+      { "internalType": "address", "name": "calledContract", "type": "address" },
+      { "internalType": "string", "name": "methodSignature", "type": "string" }
+    ],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "asset", "type": "address" },
+      { "indexed": true, "internalType": "bool", "name": "enabled", "type": "bool" }
+    ],
+    "name": "CachedEnabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "uint8", "name": "version", "type": "uint8" }],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldAccessControlManager", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newAccessControlManager", "type": "address" }
+    ],
+    "name": "NewAccessControlManager",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "asset", "type": "address" },
+      { "indexed": true, "internalType": "uint256", "name": "role", "type": "uint256" },
+      { "indexed": true, "internalType": "bool", "name": "enable", "type": "bool" }
+    ],
+    "name": "OracleEnabled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "asset", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "oracle", "type": "address" },
+      { "indexed": true, "internalType": "uint256", "name": "role", "type": "uint256" }
+    ],
+    "name": "OracleSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "address", "name": "account", "type": "address" }],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "asset", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "mainOracle", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "pivotOracle", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "fallbackOracle", "type": "address" }
+    ],
+    "name": "TokenConfigAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "address", "name": "account", "type": "address" }],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "CACHE_SLOT",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "INVALID_PRICE",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "NATIVE_TOKEN_ADDR",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "acceptOwnership", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [],
+    "name": "accessControlManager",
+    "outputs": [{ "internalType": "contract IAccessControlManagerV8", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "boundValidator",
+    "outputs": [{ "internalType": "contract BoundValidatorInterface", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "enum ResilientOracle.OracleRole", "name": "role", "type": "uint8" },
+      { "internalType": "bool", "name": "enable", "type": "bool" }
+    ],
+    "name": "enableOracle",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "enum ResilientOracle.OracleRole", "name": "role", "type": "uint8" }
+    ],
+    "name": "getOracle",
+    "outputs": [
+      { "internalType": "address", "name": "oracle", "type": "address" },
+      { "internalType": "bool", "name": "enabled", "type": "bool" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "asset", "type": "address" }],
+    "name": "getPrice",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "asset", "type": "address" }],
+    "name": "getTokenConfig",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "asset", "type": "address" },
+          { "internalType": "address[3]", "name": "oracles", "type": "address[3]" },
+          { "internalType": "bool[3]", "name": "enableFlagsForOracles", "type": "bool[3]" },
+          { "internalType": "bool", "name": "cachingEnabled", "type": "bool" }
+        ],
+        "internalType": "struct ResilientOracle.TokenConfig",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "vToken", "type": "address" }],
+    "name": "getUnderlyingPrice",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "accessControlManager_", "type": "address" }],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nativeMarket",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "pause", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "renounceOwnership", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [{ "internalType": "address", "name": "accessControlManager_", "type": "address" }],
+    "name": "setAccessControlManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "address", "name": "oracle", "type": "address" },
+      { "internalType": "enum ResilientOracle.OracleRole", "name": "role", "type": "uint8" }
+    ],
+    "name": "setOracle",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "asset", "type": "address" },
+          { "internalType": "address[3]", "name": "oracles", "type": "address[3]" },
+          { "internalType": "bool[3]", "name": "enableFlagsForOracles", "type": "bool[3]" },
+          { "internalType": "bool", "name": "cachingEnabled", "type": "bool" }
+        ],
+        "internalType": "struct ResilientOracle.TokenConfig",
+        "name": "tokenConfig",
+        "type": "tuple"
+      }
+    ],
+    "name": "setTokenConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "asset", "type": "address" },
+          { "internalType": "address[3]", "name": "oracles", "type": "address[3]" },
+          { "internalType": "bool[3]", "name": "enableFlagsForOracles", "type": "bool[3]" },
+          { "internalType": "bool", "name": "cachingEnabled", "type": "bool" }
+        ],
+        "internalType": "struct ResilientOracle.TokenConfig[]",
+        "name": "tokenConfigs_",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "setTokenConfigs",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "newOwner", "type": "address" }],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "inputs": [], "name": "unpause", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [{ "internalType": "address", "name": "asset", "type": "address" }],
+    "name": "updateAssetPrice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "vToken", "type": "address" }],
+    "name": "updatePrice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vai",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/simulations/vip-612/bscmainnet.ts
+++ b/simulations/vip-612/bscmainnet.ts
@@ -67,7 +67,7 @@ const setMaxStaleForSolvBTC = async () => {
   }
 };
 
-const setDirectPriceForSSolvBTCFundamental = async () => {
+const setDirectPriceForSolvBTCFundamental = async () => {
   const timelockSigner = await initMainnetUser(bscmainnet.NORMAL_TIMELOCK, ethers.utils.parseEther("1"));
 
   const acm = new ethers.Contract(bscmainnet.ACCESS_CONTROL_MANAGER, ACM_ABI, timelockSigner);
@@ -313,9 +313,9 @@ forking(BLOCK_NUMBER, async () => {
     });
   });
 
-  describe("set direct price for fundamental and redstore for there feed as they haev internal staenss chaeck", () => {
+  describe("set direct price for fundamental and RedStone feeds as they have internal staleness checks", () => {
     it("set Fundamnetal oracle direct price for SolvBTC", async () => {
-      await setDirectPriceForSSolvBTCFundamental();
+      await setDirectPriceForSolvBTCFundamental();
     });
 
     it("set RedStone oracle direct price for SolvBTC", async () => {

--- a/simulations/vip-612/bscmainnet.ts
+++ b/simulations/vip-612/bscmainnet.ts
@@ -1,0 +1,451 @@
+import { expect } from "chai";
+import { BigNumber, Contract } from "ethers";
+import { ethers } from "hardhat";
+import { NETWORK_ADDRESSES } from "src/networkAddresses";
+import { initMainnetUser, setMaxStalePeriodInBinanceOracle, setMaxStalePeriodInChainlinkOracle } from "src/utils";
+import { forking, testVip } from "src/vip-framework";
+
+import vip612, {
+  ATLAS_ORACLE,
+  ATLAS_U_CONFIG,
+  CHAINLINK_SOLVBTC_CONFIG,
+  CHAINLINK_U_CONFIG,
+  FUNDAMENTAL_SOLVBTC_CONFIG,
+  REDSTONE_SOLVBTC_CONFIG,
+  SOLVBTC,
+  SOLVBTC_FUNDAMENTAL_CHAINLINK_ORACLE,
+  SOLVBTC_RESILIENT_ORACLE_CONFIG,
+  U,
+  USDT_CHAINLINK_ORACLE,
+  U_RESILIENT_ORACLE_CONFIG,
+  XVS_GRANT_AMOUNT,
+  XVS_STORE,
+} from "../../vips/vip-612/bscmainnet";
+import XVS_ABI from "./abi/XVS.json";
+import ACM_ABI from "./abi/accessControlManager.json";
+import BOUND_VALIDATOR_ABI from "./abi/boundValidator.json";
+import CHAINLINK_ORACLE_ABI from "./abi/chainlinkOracle.json";
+import RESILIENT_ORACLE_ABI from "./abi/resilientOracle.json";
+
+const BOUND_VALIDATOR = "0x6E332fF0bB52475304494E4AE5063c1051c7d735";
+const SOLVBTC_UPPER_BOUND_RATIO = ethers.utils.parseUnits("1.05", 18);
+const SOLVBTC_LOWER_BOUND_RATIO = ethers.utils.parseUnits("0.95", 18);
+const U_UPPER_BOUND_RATIO = ethers.utils.parseUnits("1.01", 18);
+const U_LOWER_BOUND_RATIO = ethers.utils.parseUnits("0.99", 18);
+
+const { bscmainnet } = NETWORK_ADDRESSES;
+
+const BLOCK_NUMBER = 92480808;
+
+const STALE_PERIOD_OVERRIDE = 315360000;
+
+const setMaxStaleForU = async () => {
+  for (const oracleAddr of [bscmainnet.CHAINLINK_ORACLE, ATLAS_ORACLE]) {
+    await setMaxStalePeriodInChainlinkOracle(
+      oracleAddr,
+      U,
+      ethers.constants.AddressZero,
+      bscmainnet.NORMAL_TIMELOCK,
+      STALE_PERIOD_OVERRIDE,
+    );
+  }
+};
+
+const setMaxStaleForSolvBTC = async () => {
+  for (const oracleAddr of [
+    bscmainnet.CHAINLINK_ORACLE,
+    bscmainnet.REDSTONE_ORACLE,
+    SOLVBTC_FUNDAMENTAL_CHAINLINK_ORACLE,
+  ]) {
+    await setMaxStalePeriodInChainlinkOracle(
+      oracleAddr,
+      SOLVBTC,
+      ethers.constants.AddressZero,
+      bscmainnet.NORMAL_TIMELOCK,
+      STALE_PERIOD_OVERRIDE,
+    );
+  }
+};
+
+const setDirectPriceForSSolvBTCFundamental = async () => {
+  const timelockSigner = await initMainnetUser(bscmainnet.NORMAL_TIMELOCK, ethers.utils.parseEther("1"));
+
+  const acm = new ethers.Contract(bscmainnet.ACCESS_CONTROL_MANAGER, ACM_ABI, timelockSigner);
+  const solvBTCFundamentalOracle = new ethers.Contract(
+    SOLVBTC_FUNDAMENTAL_CHAINLINK_ORACLE,
+    CHAINLINK_ORACLE_ABI,
+    timelockSigner,
+  );
+
+  // Snapshot before any state changes so we can undo them after fetching the price
+  const snapshotId = await ethers.provider.send("evm_snapshot", []);
+
+  await solvBTCFundamentalOracle.acceptOwnership();
+  await acm.giveCallPermission(
+    SOLVBTC_FUNDAMENTAL_CHAINLINK_ORACLE,
+    "setTokenConfig(TokenConfig)",
+    bscmainnet.NORMAL_TIMELOCK,
+  );
+  await acm.giveCallPermission(
+    SOLVBTC_FUNDAMENTAL_CHAINLINK_ORACLE,
+    "setDirectPrice(address,uint256)",
+    bscmainnet.NORMAL_TIMELOCK,
+  );
+  await solvBTCFundamentalOracle.setTokenConfigs([
+    [SOLVBTC, FUNDAMENTAL_SOLVBTC_CONFIG.newFeed, FUNDAMENTAL_SOLVBTC_CONFIG.maxStalePeriod],
+  ]);
+  const price = await solvBTCFundamentalOracle.getPrice(SOLVBTC);
+
+  // Revert all state changes — only the pinned direct price survives
+  await ethers.provider.send("evm_revert", [snapshotId]);
+
+  // Re-grant setDirectPrice permission (was reverted) and pin the price
+  await acm.giveCallPermission(
+    SOLVBTC_FUNDAMENTAL_CHAINLINK_ORACLE,
+    "setDirectPrice(address,uint256)",
+    bscmainnet.NORMAL_TIMELOCK,
+  );
+  await solvBTCFundamentalOracle.setDirectPrice(SOLVBTC, price);
+};
+
+const setDirectPriceForSolvBTCRedstone = async () => {
+  const timelockSigner = await initMainnetUser(bscmainnet.NORMAL_TIMELOCK, ethers.utils.parseEther("1"));
+  const redstoneOracle = new ethers.Contract(bscmainnet.REDSTONE_ORACLE, CHAINLINK_ORACLE_ABI, timelockSigner);
+
+  // Snapshot before any state changes so we can undo them after fetching the price
+  const snapshotId = await ethers.provider.send("evm_snapshot", []);
+
+  await redstoneOracle.setTokenConfigs([
+    [SOLVBTC, REDSTONE_SOLVBTC_CONFIG.newFeed, REDSTONE_SOLVBTC_CONFIG.maxStalePeriod],
+  ]);
+  const price = await redstoneOracle.getPrice(SOLVBTC);
+
+  // Revert all state changes — only the pinned direct price survives
+  await ethers.provider.send("evm_revert", [snapshotId]);
+
+  // setDirectPrice permission already exists on the shared RedStone oracle — pin the price directly
+  await redstoneOracle.setDirectPrice(SOLVBTC, price);
+};
+
+forking(BLOCK_NUMBER, async () => {
+  const provider = ethers.provider;
+  let resilientOracle: Contract;
+  let chainlinkOracle: Contract;
+  let atlasOracle: Contract;
+  let usdtChainlinkOracle: Contract;
+  let redstoneOracle: Contract;
+  let solvBTCFundamentalOracle: Contract;
+  let boundValidator: Contract;
+  let acm: Contract;
+  let xvs: Contract;
+  let preVipPrice: BigNumber;
+  let preVipSolvBTCPrice: BigNumber;
+  let xvsStoreBalanceBefore: BigNumber;
+  let xvsUnitrollerBalanceBefore: BigNumber;
+
+  before(async () => {
+    acm = new ethers.Contract(bscmainnet.ACCESS_CONTROL_MANAGER, ACM_ABI, provider);
+    boundValidator = new ethers.Contract(BOUND_VALIDATOR, BOUND_VALIDATOR_ABI, provider);
+    resilientOracle = new ethers.Contract(bscmainnet.RESILIENT_ORACLE, RESILIENT_ORACLE_ABI, provider);
+    chainlinkOracle = new ethers.Contract(bscmainnet.CHAINLINK_ORACLE, CHAINLINK_ORACLE_ABI, provider);
+    atlasOracle = new ethers.Contract(ATLAS_ORACLE, CHAINLINK_ORACLE_ABI, provider);
+    usdtChainlinkOracle = new ethers.Contract(USDT_CHAINLINK_ORACLE, CHAINLINK_ORACLE_ABI, provider);
+    redstoneOracle = new ethers.Contract(bscmainnet.REDSTONE_ORACLE, CHAINLINK_ORACLE_ABI, provider);
+    solvBTCFundamentalOracle = new ethers.Contract(
+      SOLVBTC_FUNDAMENTAL_CHAINLINK_ORACLE,
+      CHAINLINK_ORACLE_ABI,
+      provider,
+    );
+    xvs = new ethers.Contract(bscmainnet.XVS, XVS_ABI, provider);
+
+    xvsStoreBalanceBefore = await xvs.balanceOf(XVS_STORE);
+    xvsUnitrollerBalanceBefore = await xvs.balanceOf(bscmainnet.UNITROLLER);
+    preVipPrice = await resilientOracle.getPrice(U);
+    preVipSolvBTCPrice = await resilientOracle.getPrice(SOLVBTC);
+
+    // set MAxt Stale Period for BTCB to a very high value to prevent staleness issues during testing, since BTCB feeds are used as fallback for SolvBTC in some oracles
+    const BTCB = "0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c";
+    await setMaxStalePeriodInChainlinkOracle(
+      bscmainnet.CHAINLINK_ORACLE,
+      BTCB,
+      ethers.constants.AddressZero,
+      bscmainnet.NORMAL_TIMELOCK,
+      315360000,
+    );
+
+    await setMaxStalePeriodInChainlinkOracle(
+      bscmainnet.REDSTONE_ORACLE,
+      BTCB,
+      ethers.constants.AddressZero,
+      bscmainnet.NORMAL_TIMELOCK,
+      315360000,
+    );
+    await setMaxStalePeriodInBinanceOracle(bscmainnet.BINANCE_ORACLE, "BTCB", 315360000);
+  });
+
+  describe("Pre-VIP SolvBTC oracle", () => {
+    it("should match pre-VIP ResilientOracle config for SolvBTC", async () => {
+      const tokenConfig = await resilientOracle.getTokenConfig(SOLVBTC);
+      expect(tokenConfig.oracles[0]).to.equal(SOLVBTC_RESILIENT_ORACLE_CONFIG.old.oracles[0]);
+      expect(tokenConfig.oracles[1]).to.equal(SOLVBTC_RESILIENT_ORACLE_CONFIG.old.oracles[1]);
+      expect(tokenConfig.oracles[2]).to.equal(SOLVBTC_RESILIENT_ORACLE_CONFIG.old.oracles[2]);
+      expect(tokenConfig.enableFlagsForOracles[0]).to.equal(
+        SOLVBTC_RESILIENT_ORACLE_CONFIG.old.enableFlagsForOracles[0],
+      );
+      expect(tokenConfig.enableFlagsForOracles[1]).to.equal(
+        SOLVBTC_RESILIENT_ORACLE_CONFIG.old.enableFlagsForOracles[1],
+      );
+      expect(tokenConfig.enableFlagsForOracles[2]).to.equal(
+        SOLVBTC_RESILIENT_ORACLE_CONFIG.old.enableFlagsForOracles[2],
+      );
+      expect(tokenConfig.cachingEnabled).to.equal(SOLVBTC_RESILIENT_ORACLE_CONFIG.old.cachingEnabled);
+    });
+
+    it("should match pre-VIP ChainlinkOracle feed for SolvBTC", async () => {
+      const config = await chainlinkOracle.tokenConfigs(SOLVBTC);
+      expect(config.feed).to.equal(CHAINLINK_SOLVBTC_CONFIG.oldFeed);
+      expect(config.maxStalePeriod).to.equal(CHAINLINK_SOLVBTC_CONFIG.oldMaxStalePeriod);
+    });
+
+    it("should match pre-VIP RedStoneOracle feed for SolvBTC", async () => {
+      const config = await redstoneOracle.tokenConfigs(SOLVBTC);
+      expect(config.feed).to.equal(REDSTONE_SOLVBTC_CONFIG.oldFeed);
+      expect(config.maxStalePeriod).to.equal(REDSTONE_SOLVBTC_CONFIG.oldMaxStalePeriod);
+    });
+
+    it("should match pre-VIP SolvBTCFundamentalChainlinkOracle feed for SolvBTC", async () => {
+      const config = await solvBTCFundamentalOracle.tokenConfigs(SOLVBTC);
+      expect(config.feed).to.equal(FUNDAMENTAL_SOLVBTC_CONFIG.oldFeed);
+      expect(config.maxStalePeriod).to.equal(FUNDAMENTAL_SOLVBTC_CONFIG.oldMaxStalePeriod);
+    });
+
+    it("pre-VIP SolvBTC resilient price should be positive", async () => {
+      expect(preVipSolvBTCPrice).to.be.gt(0);
+    });
+  });
+
+  describe("Pre-VIP U oracle", () => {
+    it("should match pre-VIP ResilientOracle config for U", async () => {
+      const tokenConfig = await resilientOracle.getTokenConfig(U);
+      expect(tokenConfig.oracles[0]).to.equal(U_RESILIENT_ORACLE_CONFIG.old.oracles[0]);
+      expect(tokenConfig.oracles[1]).to.equal(U_RESILIENT_ORACLE_CONFIG.old.oracles[1]);
+      expect(tokenConfig.oracles[2]).to.equal(U_RESILIENT_ORACLE_CONFIG.old.oracles[2]);
+      expect(tokenConfig.enableFlagsForOracles[0]).to.equal(U_RESILIENT_ORACLE_CONFIG.old.enableFlagsForOracles[0]);
+      expect(tokenConfig.enableFlagsForOracles[1]).to.equal(U_RESILIENT_ORACLE_CONFIG.old.enableFlagsForOracles[1]);
+      expect(tokenConfig.enableFlagsForOracles[2]).to.equal(U_RESILIENT_ORACLE_CONFIG.old.enableFlagsForOracles[2]);
+      expect(tokenConfig.cachingEnabled).to.equal(U_RESILIENT_ORACLE_CONFIG.old.cachingEnabled);
+    });
+
+    it("should match pre-VIP ChainlinkOracle feed for U", async () => {
+      const config = await chainlinkOracle.tokenConfigs(U);
+      expect(config.feed).to.equal(CHAINLINK_U_CONFIG.oldFeed);
+      expect(config.maxStalePeriod).to.equal(CHAINLINK_U_CONFIG.maxStalePeriod);
+    });
+
+    it("USDT_CHAINLINK_ORACLE should report a valid price for U", async () => {
+      const price = await usdtChainlinkOracle.getPrice(U);
+      const priceFloat = parseFloat(ethers.utils.formatUnits(price, 18));
+      expect(priceFloat).to.be.closeTo(1, 0.01);
+    });
+
+    it("pre-VIP U price should be close to $1", async () => {
+      const price = parseFloat(ethers.utils.formatUnits(preVipPrice, 18));
+      expect(price).to.be.closeTo(1, 0.01);
+    });
+  });
+
+  describe("Pre-VIP ACM permissions", () => {
+    const checkNoRole = async (contract: string, fnSig: string, account: string) => {
+      const roleHash = ethers.utils.keccak256(ethers.utils.solidityPack(["address", "string"], [contract, fnSig]));
+      expect(await acm.hasRole(roleHash, account)).to.be.false;
+    };
+
+    it("Normal Timelock should NOT have setTokenConfig permission on SolvBTCFundamentalChainlinkOracle", async () => {
+      await checkNoRole(
+        SOLVBTC_FUNDAMENTAL_CHAINLINK_ORACLE,
+        "setTokenConfig(TokenConfig)",
+        bscmainnet.NORMAL_TIMELOCK,
+      );
+    });
+
+    it("Normal Timelock should NOT have setDirectPrice permission on SolvBTCFundamentalChainlinkOracle", async () => {
+      await checkNoRole(
+        SOLVBTC_FUNDAMENTAL_CHAINLINK_ORACLE,
+        "setDirectPrice(address,uint256)",
+        bscmainnet.NORMAL_TIMELOCK,
+      );
+    });
+
+    it("Normal Timelock should NOT have setTokenConfig permission on AtlasOracle", async () => {
+      await checkNoRole(ATLAS_ORACLE, "setTokenConfig(TokenConfig)", bscmainnet.NORMAL_TIMELOCK);
+    });
+
+    it("Normal Timelock should NOT have setDirectPrice permission on AtlasOracle", async () => {
+      await checkNoRole(ATLAS_ORACLE, "setDirectPrice(address,uint256)", bscmainnet.NORMAL_TIMELOCK);
+    });
+  });
+
+  describe("Pre-VIP XVS", () => {
+    it("XVSStore XVS balance should be recorded before VIP", async () => {
+      expect(xvsStoreBalanceBefore).to.be.gte(0);
+    });
+  });
+
+  describe("Pre-VIP BoundValidator configs", () => {
+    it("SolvBTC should have upperBoundRatio = 1.05e18", async () => {
+      const config = await boundValidator.validateConfigs(SOLVBTC);
+      expect(config.upperBoundRatio).to.equal(SOLVBTC_UPPER_BOUND_RATIO);
+    });
+
+    it("SolvBTC should have lowerBoundRatio = 0.95e18", async () => {
+      const config = await boundValidator.validateConfigs(SOLVBTC);
+      expect(config.lowerBoundRatio).to.equal(SOLVBTC_LOWER_BOUND_RATIO);
+    });
+
+    it("U should have upperBoundRatio = 1.01e18", async () => {
+      const config = await boundValidator.validateConfigs(U);
+      expect(config.upperBoundRatio).to.equal(U_UPPER_BOUND_RATIO);
+    });
+
+    it("U should have lowerBoundRatio = 0.99e18", async () => {
+      const config = await boundValidator.validateConfigs(U);
+      expect(config.lowerBoundRatio).to.equal(U_LOWER_BOUND_RATIO);
+    });
+  });
+
+  describe("set direct price for fundamental and redstore for there feed as they haev internal staenss chaeck", () => {
+    it("set Fundamnetal oracle direct price for SolvBTC", async () => {
+      await setDirectPriceForSSolvBTCFundamental();
+    });
+
+    it("set RedStone oracle direct price for SolvBTC", async () => {
+      await setDirectPriceForSolvBTCRedstone();
+    });
+  });
+
+  testVip("VIP-612", await vip612());
+
+  describe("Post-VIP SolvBTC oracle", () => {
+    it("should match post-VIP ResilientOracle config for SolvBTC", async () => {
+      const tokenConfig = await resilientOracle.getTokenConfig(SOLVBTC);
+      expect(tokenConfig.oracles[0]).to.equal(SOLVBTC_RESILIENT_ORACLE_CONFIG.new.oracles[0]);
+      expect(tokenConfig.oracles[1]).to.equal(SOLVBTC_RESILIENT_ORACLE_CONFIG.new.oracles[1]);
+      expect(tokenConfig.oracles[2]).to.equal(SOLVBTC_RESILIENT_ORACLE_CONFIG.new.oracles[2]);
+      expect(tokenConfig.enableFlagsForOracles[0]).to.equal(
+        SOLVBTC_RESILIENT_ORACLE_CONFIG.new.enableFlagsForOracles[0],
+      );
+      expect(tokenConfig.enableFlagsForOracles[1]).to.equal(
+        SOLVBTC_RESILIENT_ORACLE_CONFIG.new.enableFlagsForOracles[1],
+      );
+      expect(tokenConfig.enableFlagsForOracles[2]).to.equal(
+        SOLVBTC_RESILIENT_ORACLE_CONFIG.new.enableFlagsForOracles[2],
+      );
+      expect(tokenConfig.cachingEnabled).to.equal(SOLVBTC_RESILIENT_ORACLE_CONFIG.new.cachingEnabled);
+    });
+
+    it("should match post-VIP ChainlinkOracle feed for SolvBTC", async () => {
+      const config = await chainlinkOracle.tokenConfigs(SOLVBTC);
+      expect(config.feed).to.equal(CHAINLINK_SOLVBTC_CONFIG.newFeed);
+      expect(config.maxStalePeriod).to.equal(CHAINLINK_SOLVBTC_CONFIG.maxStalePeriod);
+    });
+
+    it("should match post-VIP RedStoneOracle feed for SolvBTC", async () => {
+      const config = await redstoneOracle.tokenConfigs(SOLVBTC);
+      expect(config.feed).to.equal(REDSTONE_SOLVBTC_CONFIG.newFeed);
+      expect(config.maxStalePeriod).to.equal(REDSTONE_SOLVBTC_CONFIG.maxStalePeriod);
+    });
+
+    it("should match post-VIP SolvBTCFundamentalChainlinkOracle feed for SolvBTC", async () => {
+      const config = await solvBTCFundamentalOracle.tokenConfigs(SOLVBTC);
+      expect(config.feed).to.equal(FUNDAMENTAL_SOLVBTC_CONFIG.newFeed);
+      expect(config.maxStalePeriod).to.equal(FUNDAMENTAL_SOLVBTC_CONFIG.maxStalePeriod);
+    });
+
+    it("post-VIP SolvBTC price should be within 1% of pre-VIP price", async () => {
+      await setMaxStaleForSolvBTC();
+      const postVipPrice = await resilientOracle.getPrice(SOLVBTC);
+      const pre = parseFloat(ethers.utils.formatUnits(preVipSolvBTCPrice, 18));
+      const post = parseFloat(ethers.utils.formatUnits(postVipPrice, 18));
+      expect(post).to.be.closeTo(pre, pre * 0.01);
+    });
+  });
+
+  describe("Post-VIP U oracle", () => {
+    it("should match post-VIP ResilientOracle config for U", async () => {
+      const tokenConfig = await resilientOracle.getTokenConfig(U);
+      expect(tokenConfig.oracles[0]).to.equal(U_RESILIENT_ORACLE_CONFIG.new.oracles[0]);
+      expect(tokenConfig.oracles[1]).to.equal(U_RESILIENT_ORACLE_CONFIG.new.oracles[1]);
+      expect(tokenConfig.oracles[2]).to.equal(U_RESILIENT_ORACLE_CONFIG.new.oracles[2]);
+      expect(tokenConfig.enableFlagsForOracles[0]).to.equal(U_RESILIENT_ORACLE_CONFIG.new.enableFlagsForOracles[0]);
+      expect(tokenConfig.enableFlagsForOracles[1]).to.equal(U_RESILIENT_ORACLE_CONFIG.new.enableFlagsForOracles[1]);
+      expect(tokenConfig.enableFlagsForOracles[2]).to.equal(U_RESILIENT_ORACLE_CONFIG.new.enableFlagsForOracles[2]);
+      expect(tokenConfig.cachingEnabled).to.equal(U_RESILIENT_ORACLE_CONFIG.new.cachingEnabled);
+    });
+
+    it("should match post-VIP ChainlinkOracle feed for U", async () => {
+      const config = await chainlinkOracle.tokenConfigs(U);
+      expect(config.feed).to.equal(CHAINLINK_U_CONFIG.newFeed);
+      expect(config.maxStalePeriod).to.equal(CHAINLINK_U_CONFIG.maxStalePeriod);
+    });
+
+    it("should match post-VIP AtlasOracle feed for U", async () => {
+      const config = await atlasOracle.tokenConfigs(U);
+      expect(config.feed).to.equal(ATLAS_U_CONFIG.feed);
+      expect(config.maxStalePeriod).to.equal(ATLAS_U_CONFIG.maxStalePeriod);
+    });
+
+    it("post-VIP U price should be within 1% of pre-VIP price", async () => {
+      await setMaxStaleForU();
+
+      const postVipPrice = await resilientOracle.getPrice(U);
+      const pre = parseFloat(ethers.utils.formatUnits(preVipPrice, 18));
+      const post = parseFloat(ethers.utils.formatUnits(postVipPrice, 18));
+      expect(post).to.be.closeTo(pre, pre * 0.01);
+    });
+
+    it("post-VIP U price should still be close to $1", async () => {
+      const postVipPrice = await resilientOracle.getPrice(U);
+      const price = parseFloat(ethers.utils.formatUnits(postVipPrice, 18));
+      expect(price).to.be.closeTo(1, 0.01);
+    });
+  });
+
+  describe("Post-VIP XVS base reward", () => {
+    it("XVSStore XVS balance should increase by XVS_GRANT_AMOUNT", async () => {
+      const xvsStoreBalanceAfter = await xvs.balanceOf(XVS_STORE);
+      expect(xvsStoreBalanceAfter.sub(xvsStoreBalanceBefore)).to.equal(XVS_GRANT_AMOUNT);
+    });
+
+    it("Unitroller XVS balance should decrease by XVS_GRANT_AMOUNT", async () => {
+      const xvsUnitrollerBalanceAfter = await xvs.balanceOf(bscmainnet.UNITROLLER);
+      expect(xvsUnitrollerBalanceBefore.sub(xvsUnitrollerBalanceAfter)).to.equal(XVS_GRANT_AMOUNT);
+    });
+  });
+
+  describe("Post-VIP ACM permissions", () => {
+    const checkRole = async (contract: string, fnSig: string, account: string) => {
+      const roleHash = ethers.utils.keccak256(ethers.utils.solidityPack(["address", "string"], [contract, fnSig]));
+      expect(await acm.hasRole(roleHash, account)).to.be.true;
+    };
+
+    it("Normal Timelock should have setTokenConfig permission on SolvBTCFundamentalChainlinkOracle", async () => {
+      await checkRole(SOLVBTC_FUNDAMENTAL_CHAINLINK_ORACLE, "setTokenConfig(TokenConfig)", bscmainnet.NORMAL_TIMELOCK);
+    });
+
+    it("Normal Timelock should have setDirectPrice permission on SolvBTCFundamentalChainlinkOracle", async () => {
+      await checkRole(
+        SOLVBTC_FUNDAMENTAL_CHAINLINK_ORACLE,
+        "setDirectPrice(address,uint256)",
+        bscmainnet.NORMAL_TIMELOCK,
+      );
+    });
+
+    it("Normal Timelock should have setTokenConfig permission on AtlasOracle", async () => {
+      await checkRole(ATLAS_ORACLE, "setTokenConfig(TokenConfig)", bscmainnet.NORMAL_TIMELOCK);
+    });
+
+    it("Normal Timelock should have setDirectPrice permission on AtlasOracle", async () => {
+      await checkRole(ATLAS_ORACLE, "setDirectPrice(address,uint256)", bscmainnet.NORMAL_TIMELOCK);
+    });
+  });
+});

--- a/simulations/vip-612/bscmainnet.ts
+++ b/simulations/vip-612/bscmainnet.ts
@@ -6,6 +6,8 @@ import { initMainnetUser, setMaxStalePeriodInBinanceOracle, setMaxStalePeriodInC
 import { forking, testVip } from "src/vip-framework";
 
 import vip612, {
+  ALLEZ_LABS,
+  ALLEZ_LABS_USDT_AMOUNT,
   ATLAS_ORACLE,
   ATLAS_U_CONFIG,
   CHAINLINK_SOLVBTC_CONFIG,
@@ -16,6 +18,7 @@ import vip612, {
   SOLVBTC_FUNDAMENTAL_CHAINLINK_ORACLE,
   SOLVBTC_RESILIENT_ORACLE_CONFIG,
   U,
+  USDT,
   USDT_CHAINLINK_ORACLE,
   U_RESILIENT_ORACLE_CONFIG,
   XVS_GRANT_AMOUNT,
@@ -35,7 +38,7 @@ const U_LOWER_BOUND_RATIO = ethers.utils.parseUnits("0.99", 18);
 
 const { bscmainnet } = NETWORK_ADDRESSES;
 
-const BLOCK_NUMBER = 92480808;
+const BLOCK_NUMBER = 92819471;
 
 const STALE_PERIOD_OVERRIDE = 315360000;
 
@@ -145,10 +148,13 @@ forking(BLOCK_NUMBER, async () => {
   let boundValidator: Contract;
   let acm: Contract;
   let xvs: Contract;
+  let usdt: Contract;
   let preVipPrice: BigNumber;
   let preVipSolvBTCPrice: BigNumber;
   let xvsStoreBalanceBefore: BigNumber;
   let xvsUnitrollerBalanceBefore: BigNumber;
+  let allezLabsUsdtBalanceBefore: BigNumber;
+  let treasuryUsdtBalanceBefore: BigNumber;
 
   before(async () => {
     acm = new ethers.Contract(bscmainnet.ACCESS_CONTROL_MANAGER, ACM_ABI, provider);
@@ -164,9 +170,12 @@ forking(BLOCK_NUMBER, async () => {
       provider,
     );
     xvs = new ethers.Contract(bscmainnet.XVS, XVS_ABI, provider);
+    usdt = new ethers.Contract(USDT, XVS_ABI, provider);
 
     xvsStoreBalanceBefore = await xvs.balanceOf(XVS_STORE);
     xvsUnitrollerBalanceBefore = await xvs.balanceOf(bscmainnet.UNITROLLER);
+    allezLabsUsdtBalanceBefore = await usdt.balanceOf(ALLEZ_LABS);
+    treasuryUsdtBalanceBefore = await usdt.balanceOf(bscmainnet.VTREASURY);
     preVipPrice = await resilientOracle.getPrice(U);
     preVipSolvBTCPrice = await resilientOracle.getPrice(SOLVBTC);
 
@@ -301,6 +310,12 @@ forking(BLOCK_NUMBER, async () => {
     });
   });
 
+  describe("Pre-VIP Allez Labs payment", () => {
+    it("Treasury USDT balance should be recorded before VIP", async () => {
+      expect(treasuryUsdtBalanceBefore).to.be.gte(ALLEZ_LABS_USDT_AMOUNT);
+    });
+  });
+
   describe("Pre-VIP BoundValidator configs", () => {
     it("SolvBTC should have upperBoundRatio = 1.05e18", async () => {
       const config = await boundValidator.validateConfigs(SOLVBTC);
@@ -432,6 +447,18 @@ forking(BLOCK_NUMBER, async () => {
     it("Unitroller XVS balance should decrease by XVS_GRANT_AMOUNT", async () => {
       const xvsUnitrollerBalanceAfter = await xvs.balanceOf(bscmainnet.UNITROLLER);
       expect(xvsUnitrollerBalanceBefore.sub(xvsUnitrollerBalanceAfter)).to.equal(XVS_GRANT_AMOUNT);
+    });
+  });
+
+  describe("Post-VIP Allez Labs payment", () => {
+    it("Allez Labs USDT balance should increase by 105,000 USDT", async () => {
+      const allezLabsUsdtBalanceAfter = await usdt.balanceOf(ALLEZ_LABS);
+      expect(allezLabsUsdtBalanceAfter.sub(allezLabsUsdtBalanceBefore)).to.equal(ALLEZ_LABS_USDT_AMOUNT);
+    });
+
+    it("Treasury USDT balance should decrease by 105,000 USDT", async () => {
+      const treasuryUsdtBalanceAfter = await usdt.balanceOf(bscmainnet.VTREASURY);
+      expect(treasuryUsdtBalanceBefore.sub(treasuryUsdtBalanceAfter)).to.equal(ALLEZ_LABS_USDT_AMOUNT);
     });
   });
 

--- a/simulations/vip-612/bscmainnet.ts
+++ b/simulations/vip-612/bscmainnet.ts
@@ -67,6 +67,13 @@ const setMaxStaleForSolvBTC = async () => {
   }
 };
 
+// Workaround for internal staleness checks in the Fundamental and RedStone oracles:
+// After VIP execution the new feeds will be stale at the forked block, causing getPrice() to revert.
+// Instead of skipping the price check entirely, this function simulates the feed returning the correct
+// price by temporarily configuring the new feed, reading the price it would return, then reverting all
+// state changes. The fetched price is then pinned via setDirectPrice so the oracle returns it without
+// consulting the (stale) feed. This way the test exercises the full oracle stack — feed → oracle →
+// resilient oracle — while working around the block-timestamp staleness constraint.
 const setDirectPriceForSolvBTCFundamental = async () => {
   const timelockSigner = await initMainnetUser(bscmainnet.NORMAL_TIMELOCK, ethers.utils.parseEther("1"));
 
@@ -220,7 +227,9 @@ forking(BLOCK_NUMBER, async () => {
     });
 
     it("pre-VIP SolvBTC resilient price should be positive", async () => {
-      expect(preVipSolvBTCPrice).to.be.gt(0);
+      const price = parseFloat(ethers.utils.formatUnits(preVipSolvBTCPrice, 18));
+      console.log(`Pre-VIP SolvBTC price: $${price}`);
+      expect(price).to.be.gt(70000);
     });
   });
 
@@ -250,6 +259,7 @@ forking(BLOCK_NUMBER, async () => {
 
     it("pre-VIP U price should be close to $1", async () => {
       const price = parseFloat(ethers.utils.formatUnits(preVipPrice, 18));
+      console.log(`Pre-VIP U price: $${price}`);
       expect(price).to.be.closeTo(1, 0.01);
     });
   });
@@ -366,6 +376,7 @@ forking(BLOCK_NUMBER, async () => {
       const postVipPrice = await resilientOracle.getPrice(SOLVBTC);
       const pre = parseFloat(ethers.utils.formatUnits(preVipSolvBTCPrice, 18));
       const post = parseFloat(ethers.utils.formatUnits(postVipPrice, 18));
+      console.log(`Post-VIP SolvBTC price: $${post} (diff from pre: ${(post - pre).toFixed(2)})`);
       expect(post).to.be.closeTo(pre, pre * 0.01);
     });
   });
@@ -406,6 +417,8 @@ forking(BLOCK_NUMBER, async () => {
     it("post-VIP U price should still be close to $1", async () => {
       const postVipPrice = await resilientOracle.getPrice(U);
       const price = parseFloat(ethers.utils.formatUnits(postVipPrice, 18));
+      const pre = parseFloat(ethers.utils.formatUnits(preVipPrice, 18));
+      console.log(`Post-VIP U price: $${price} (diff from pre: ${(price - pre).toFixed(6)})`);
       expect(price).to.be.closeTo(1, 0.01);
     });
   });

--- a/vips/vip-612/bscmainnet.ts
+++ b/vips/vip-612/bscmainnet.ts
@@ -112,45 +112,115 @@ export const vip612 = () => {
   const meta = {
     version: "v2",
     title:
-      "VIP-612 [BNB Chain] SolvBTC Oracle Setup + U Oracle Switch to Dedicated Feeds + XVS Base Reward Grant + Allez Labs Quarterly Payment",
-    description: `## Summary
+      "VIP-612 [BNB Chain] 2026 Week 16 VIP: solvBTC & U Oracle Upgrades, Allez Labs Q2 Payment & XVS Vault Base Reward Top-up",
+    description: `#### Summary
 
-This VIP performs four independent actions on BNB Chain:
+This VIP bundles four protocol actions on BNB Chain:
 
-### 1. SolvBTC Oracle Setup
+1. **Switch solvBTC oracle** from RedStone market price feed to a manipulation-resistant CorrelatedTokenOracle (RedStone exchange rate feed), replace BinanceOracle PIVOT with Chainlink Exchange Rate feed, and add a RedStone cross-market FALLBACK — upgrading from Tier 2 to Full (3 oracles).
+2. **Switch U oracle** from non-dedicated Chainlink USDT/USD1 feeds to dedicated Chainlink U/USD (MAIN) and Atlas U/USD (PIVOT) feeds.
+3. **Transfer $105,000 USDT** from Venus Treasury to Allez Labs for Q2 2026 risk management services.
+4. **Fund XVS Vault base rewards** by calling _grantXVS to transfer ~55,875 XVS from the Core Pool Comptroller to the XVS Store, covering Q1–Q2 2026.
 
-Configures a three-tier resilient oracle for SolvBTC/USD pricing using the OneJump pattern
-(SolvBTC/BTC rate × BTCB/USD = SolvBTC/USD):
-- **MAIN**: CorrelatedTokenOracle (SolvBTCOneJumpFundamentalOracle) using the Solv self-reported fundamental rate
-- **PIVOT**: OneJumpOracle (SolvBTCOneJumpChainlinkOracle) using the Chainlink ER feed
-- **FALLBACK**: OneJumpOracle (SolvBTCOneJumpRedStoneOracle) using the RedStone cross-market feed
+#### Description
 
-Also grants ACM permissions to the Normal Timelock for the freshly deployed SolvBTCFundamentalChainlinkOracle.
+#### 1. [BNB Chain] solvBTC Oracle Switch to Exchange Rate Feed
 
-### 2. U Oracle Update (VPD-996)
+**Context**
 
-Venus currently prices U using non-dedicated oracle feeds (USDT Chainlink as MAIN, USD1 Chainlink as PIVOT).
-Both Chainlink and Atlas (formerly CMC) have deployed dedicated U/USD feeds on BNB Chain.
-This VIP switches to the dedicated feeds:
-- **MAIN**: ChainlinkOracle with dedicated Chainlink U/USD feed (0x2Ab73dc1C8A23bcDDb4850Ff811850E0d2a0c72f)
-- **PIVOT**: AtlasOracle with dedicated Atlas U/USD feed (0x14a20eafffada4d78afeef1185e7317cf98f6a1f)
-- maxStalePeriod: 86,700s (24h + 5min), deviation: 0.5%
+solvBTC has low spot trading volume on BSC DEXs, making the current RedStone market price feed vulnerable to manipulation. Solv has requested switching to exchange rate feeds. Chainlink ER feed is now live on BNB Chain.
 
-### 3. XVS Base Reward Grant (VPD-1024)
+**Current Configuration**
 
-The fixed Base Reward allocation of 308.7 XVS/day on BNB Chain has not been funded for any period in 2026.
-Last grant was VIP-529 (July 2025), covering through 2025-12-31.
+- MAIN: RedStoneOracle, RS:SolvBTC (0xF5F6...a550), deviation 0.5%, heartbeat 6h, max_stale 21,900s
+- PIVOT: BinanceOracle, BN:SOLVBTC, deviation 1.0%, heartbeat 12h, max_stale 43,500s
+- FALLBACK: N/A
 
-Outstanding amounts:
+**Proposed Configuration**
+
+- MAIN: CorrelatedTokenOracle, [RS:SolvBTC_FUNDAMENTAL](https://app.redstone.finance/app/feeds/bnb-chain/solvbtc_fundamental/), address 0x77471661568DC65d4574EAd9544DfF1e618Adfb2, deviation 0.01%, heartbeat 24h, max_stale 86,700s
+- PIVOT: ChainlinkOracle, CL:solvBTC/BTC Exchange Rate, address 0xf93b9B23c46331704EC550c24CB4110975057863, deviation 1.0%, heartbeat 24h, max_stale 86,700s
+- FALLBACK: RedStoneOracle, SolvBTC/BTC cross-market (~14 CEX), address 0x8D89d6c114193154f111D7C83299D285C9cC5BBC, deviation 0.5%, heartbeat 6h, max_stale 21,900s
+
+Tier: Full (MAIN + PIVOT + FALLBACK)
+
+**Key Changes**
+
+- MAIN: RedStone SolvBTC_FUNDAMENTAL exchange rate feed via CorrelatedTokenOracle — immune to spot market manipulation
+- PIVOT: Chainlink solvBTC/BTC Exchange Rate feed — replaces BinanceOracle to align with Solv's migration away from market rate feeds
+- FALLBACK: RedStone cross-market feed aggregating ~14 CEX sources — provides market price backup
+- max_stale = provider heartbeat + 300s (consistent with protocol-wide oracle audit recommendation)
+
+**Actions**
+
+- Configure CorrelatedTokenOracle for solvBTC with SolvBTC_FUNDAMENTAL feed
+- Set MAIN oracle to CorrelatedTokenOracle, max_stale = 86,700s
+- Set PIVOT oracle to ChainlinkOracle with solvBTC/BTC ER feed, max_stale = 86,700s
+- Configure FALLBACK oracle to RedStoneOracle with SolvBTC/BTC cross-market feed, max_stale = 21,900s
+
+#### 2. [BNB Chain] U Oracle — Switch to Dedicated Feeds
+
+**Context**
+
+Venus currently prices U using non-dedicated oracles (Chainlink USDT and USD1 as proxies). Both Chainlink and Atlas (formerly CMC) have now deployed dedicated U/USD feeds on BNB Chain.
+
+**Current Configuration**
+
+- MAIN: ChainlinkOracle (capped), Stabilized USDT Price Feed (non-dedicated), address 0xF884002406Ac6Fd93FF5C989506220f781A97eEA, max_stale 100s
+- PIVOT: ChainlinkOracle, USD1/USD (non-dedicated), max_stale 86,700s
+- FALLBACK: N/A
+
+Tier: 2 (MAIN + PIVOT only)
+
+**Proposed Configuration**
+
+- MAIN: ChainlinkOracle, [U/USD (dedicated)](https://data.chain.link/feeds/bsc/mainnet/u-usd), address 0x2Ab73dc1C8A23bcDDb4850Ff811850E0d2a0c72f, deviation 0.5%, heartbeat 24h, max_stale 86,700s
+- PIVOT: Atlas (formerly CMC), [U/USD (dedicated)](https://bscscan.com/address/0x14a20eafffada4d78afeef1185e7317cf98f6a1f), address 0x14a20eafffada4d78afeef1185e7317cf98f6a1f, deviation 0.5%, heartbeat 24h, max_stale 86,700s
+
+Tier: 2 (MAIN + PIVOT)
+
+**Actions**
+
+- Set MAIN oracle to ChainlinkOracle with dedicated U/USD feed, max_stale = 86,700s
+- Set PIVOT oracle to Atlas with dedicated U/USD feed, max_stale = 86,700s
+
+#### 3. [BNB Chain] Allez Labs Q2 2026 Risk Services Payment
+
+**Context**
+
+Allez Labs provides risk management services to Venus Protocol. Per the contract terms, fees are paid quarterly in advance starting Q2 2026. This is the payment covering Q2 2026 (26 April 2026 – 25 July 2026).
+
+**Transfer Details**
+
+- Amount: 105,000 USDT
+- Source: Venus Treasury (0xf322942f644a996a617bd29c16bd7d231d9f35e9)
+- Destination: Allez Labs (0x1757564C8C9a2c3cbE12620ea21B97d6E149F98e)
+- Period: Q2 2026 (April – July)
+- Basis: $35,000/month × 3 months
+
+**Actions**
+
+- Direct Transfer 105,000 USDT from Venus Treasury to Allez Labs at 0x1757564C8C9a2c3cbE12620ea21B97d6E149F98e
+
+#### 4. [BNB Chain] Fund XVS Vault Base Rewards for H1 2026
+
+The fixed Base Reward allocation of 308.7 XVS/day on BNB Chain has not been funded from the Core Pool Comptroller since [VIP-529](https://app.venus.io/#/governance/proposal/529?chainId=56) (July 2025), which only covered through 2025-12-31. Both Q1 and Q2 2026 base rewards are outstanding.
+
+**Outstanding Amount**
+
 - Q1 2026: 90 days × 308.7 = 27,783 XVS
 - Q2 2026: 91 days × 308.7 = 28,092 XVS
-- Total: 55,875 XVS
+- Total: ~55,875 XVS
 
-This VIP calls _grantXVS on the Core Pool Comptroller to transfer 55,875 XVS directly to XVSStore.
+**Actions**
 
-### 4. Allez Labs Quarterly Payment
+- Call _grantXVS(XVS_STORE, ~55,875) on the Core Pool Comptroller to transfer XVS to the [XVS Store](https://bscscan.com/address/0x1e25CF968f12850003Db17E0Dba32108509C4359)
 
-Transfers 105,000 USDT from the Venus Treasury to Allez Labs (0x1757564C8C9a2c3cbE12620ea21B97d6E149F98e) as their quarterly payment.`,
+#### Voting options
+
+- **For** — Execute this proposal
+- **Against** — Do not execute this proposal
+- **Abstain** — Indifferent to execution`,
     forDescription: "I agree that Venus Protocol should proceed with this proposal",
     againstDescription: "I do not think that Venus Protocol should proceed with this proposal",
     abstainDescription: "I am indifferent to whether Venus Protocol proceeds or not",

--- a/vips/vip-612/bscmainnet.ts
+++ b/vips/vip-612/bscmainnet.ts
@@ -1,0 +1,257 @@
+import { parseUnits } from "ethers/lib/utils";
+import { ethers } from "hardhat";
+import { NETWORK_ADDRESSES } from "src/networkAddresses";
+import { ProposalType } from "src/types";
+import { makeProposal } from "src/utils";
+
+const { bscmainnet } = NETWORK_ADDRESSES;
+
+// ================================================================================
+// ===== SolvBTC Oracle Setup =====
+// ================================================================================
+export const SOLVBTC = "0x4aae823a6a0b376De6A78e74eCC5b079d38cBCf7";
+
+export const CHAINLINK_SOLVBTC_CONFIG = {
+  oldFeed: "0x264990fbd0A4796A3E3d8E37C4d5F87a3aCa5Ebf",
+  oldMaxStalePeriod: 100,
+  newFeed: "0xf93b9B23c46331704EC550c24CB4110975057863", // Chainlink ER feed
+  maxStalePeriod: 86700, // 24h + 5min
+};
+
+export const REDSTONE_SOLVBTC_CONFIG = {
+  oldFeed: "0xF5F641fF3c7E39876A76e77E84041C300DFa4550",
+  oldMaxStalePeriod: 21900,
+  newFeed: "0x8D89d6c114193154f111D7C83299D285C9cC5BBC", // RedStone cross-market
+  maxStalePeriod: 21900, // 6h + 5min
+};
+
+export const FUNDAMENTAL_SOLVBTC_CONFIG = {
+  oldFeed: ethers.constants.AddressZero,
+  oldMaxStalePeriod: 0,
+  newFeed: "0x77471661568DC65d4574EAd9544DfF1e618Adfb2", // Solv self-reported rate
+  maxStalePeriod: 86700, // 24h + 5min
+};
+
+export const SOLVBTC_FUNDAMENTAL_CHAINLINK_ORACLE = "0x4521589226ef07d9805936de42F1ACF394B2B221"; // ChainlinkOracle proxy (Ownable2Step)
+export const SOLVBTC_ONE_JUMP_FUNDAMENTAL_ORACLE = "0x1f785B1AFE0808d69d1188db9e47b7B9Dd95ab09"; // CorrelatedTokenOracle (fundamental rate)
+export const SOLVBTC_ONE_JUMP_CHAINLINK_ORACLE = "0x3f4bC081E749032cffF29dcA2E8408Ec375e745A"; // OneJumpOracle (Chainlink ER)
+export const SOLVBTC_ONE_JUMP_REDSTONE_ORACLE = "0xA3E6F08e3C1baD83e1971909483F27Cdd19937FC"; // OneJumpOracle (RedStone cross-market)
+
+export const SOLVBTC_RESILIENT_ORACLE_CONFIG = {
+  old: {
+    oracles: [bscmainnet.REDSTONE_ORACLE, bscmainnet.BINANCE_ORACLE, ethers.constants.AddressZero] as [
+      string,
+      string,
+      string,
+    ],
+    enableFlagsForOracles: [true, true, false] as [boolean, boolean, boolean],
+    cachingEnabled: false,
+  },
+  new: {
+    oracles: [
+      SOLVBTC_ONE_JUMP_FUNDAMENTAL_ORACLE,
+      SOLVBTC_ONE_JUMP_CHAINLINK_ORACLE,
+      SOLVBTC_ONE_JUMP_REDSTONE_ORACLE,
+    ] as [string, string, string],
+    enableFlagsForOracles: [true, true, false] as [boolean, boolean, boolean],
+    cachingEnabled: false,
+  },
+};
+
+// ================================================================================
+// ===== U Oracle Update =====
+// ================================================================================
+export const U = "0xcE24439F2D9C6a2289F741120FE202248B666666";
+
+export const USDT_CHAINLINK_ORACLE = "0x22Dc2BAEa32E95AB07C2F5B8F63336CbF61aB6b8";
+export const ATLAS_ORACLE = "0x9E6928Ec418948ceb9f1cd9872fD312b13D841D0";
+
+export const CHAINLINK_U_CONFIG = {
+  asset: U,
+  oldFeed: "0xaD8b4e59A7f25B68945fAf0f3a3EAF027832FFB0",
+  newFeed: "0x2Ab73dc1C8A23bcDDb4850Ff811850E0d2a0c72f",
+  maxStalePeriod: 86700,
+};
+
+export const ATLAS_U_CONFIG = {
+  asset: U,
+  feed: "0x14a20EAFffadA4d78aFEeF1185E7317CF98f6A1F",
+  maxStalePeriod: 86700,
+};
+
+export const U_RESILIENT_ORACLE_CONFIG = {
+  old: {
+    oracles: [USDT_CHAINLINK_ORACLE, bscmainnet.CHAINLINK_ORACLE, ethers.constants.AddressZero],
+    enableFlagsForOracles: [true, true, false],
+    cachingEnabled: false,
+  },
+  new: {
+    oracles: [bscmainnet.CHAINLINK_ORACLE, ATLAS_ORACLE, ethers.constants.AddressZero],
+    enableFlagsForOracles: [true, true, false],
+    cachingEnabled: false,
+  },
+};
+
+// ================================================================================
+// ===== XVS Base Reward Grant =====
+// ================================================================================
+// Q1 2026: 90 days × 308.7 XVS/day = 27,783 XVS
+// Q2 2026: 91 days × 308.7 XVS/day = 28,092 XVS
+// Total outstanding: 55,875 XVS
+export const XVS_STORE = "0x1e25CF968f12850003Db17E0Dba32108509C4359";
+export const XVS_GRANT_AMOUNT = parseUnits("55875", 18);
+
+export const vip612 = () => {
+  const meta = {
+    version: "v2",
+    title: "VIP-612 [BNB Chain] SolvBTC Oracle Setup + U Oracle Switch to Dedicated Feeds + XVS Base Reward Grant",
+    description: `## Summary
+
+This VIP performs three independent actions on BNB Chain:
+
+### 1. SolvBTC Oracle Setup
+
+Configures a three-tier resilient oracle for SolvBTC/USD pricing using the OneJump pattern
+(SolvBTC/BTC rate × BTCB/USD = SolvBTC/USD):
+- **MAIN**: OneJumpOracle (SolvBTCOneJumpRedStoneOracle) using the RedStone cross-market feed
+- **PIVOT**: OneJumpOracle (SolvBTCOneJumpChainlinkOracle) using the Chainlink ER feed
+- **FALLBACK**: CorrelatedTokenOracle (SolvBTCOneJumpFundamentalOracle) using the Solv self-reported fundamental feed
+
+Also grants ACM permissions to the Normal Timelock for the freshly deployed SolvBTCFundamentalChainlinkOracle.
+
+### 2. U Oracle Update (VPD-996)
+
+Venus currently prices U using non-dedicated oracle feeds (USDT Chainlink as MAIN, USD1 Chainlink as PIVOT).
+Both Chainlink and Atlas (formerly CMC) have deployed dedicated U/USD feeds on BNB Chain.
+This VIP switches to the dedicated feeds:
+- **MAIN**: ChainlinkOracle with dedicated Chainlink U/USD feed (0x2Ab73dc1C8A23bcDDb4850Ff811850E0d2a0c72f)
+- **PIVOT**: AtlasOracle with dedicated Atlas U/USD feed (0x14a20eafffada4d78afeef1185e7317cf98f6a1f)
+- maxStalePeriod: 86,700s (24h + 5min), deviation: 0.5%
+
+### 3. XVS Base Reward Grant (VPD-1024)
+
+The fixed Base Reward allocation of 308.7 XVS/day on BNB Chain has not been funded for any period in 2026.
+Last grant was VIP-529 (July 2025), covering through 2025-12-31.
+
+Outstanding amounts:
+- Q1 2026: 90 days × 308.7 = 27,783 XVS
+- Q2 2026: 91 days × 308.7 = 28,092 XVS
+- Total: 55,875 XVS
+
+This VIP calls _grantXVS on the Core Pool Comptroller to transfer 55,875 XVS directly to XVSStore.`,
+    forDescription: "I agree that Venus Protocol should proceed with this proposal",
+    againstDescription: "I do not think that Venus Protocol should proceed with this proposal",
+    abstainDescription: "I am indifferent to whether Venus Protocol proceeds or not",
+  };
+
+  return makeProposal(
+    [
+      // ================================================================================
+      // ===== 1. SolvBTC Oracle Setup =====
+      // ================================================================================
+
+      {
+        target: SOLVBTC_FUNDAMENTAL_CHAINLINK_ORACLE,
+        signature: "acceptOwnership()",
+        params: [],
+      },
+      {
+        target: bscmainnet.ACCESS_CONTROL_MANAGER,
+        signature: "giveCallPermission(address,string,address)",
+        params: [SOLVBTC_FUNDAMENTAL_CHAINLINK_ORACLE, "setTokenConfig(TokenConfig)", bscmainnet.NORMAL_TIMELOCK],
+      },
+      {
+        target: bscmainnet.ACCESS_CONTROL_MANAGER,
+        signature: "giveCallPermission(address,string,address)",
+        params: [SOLVBTC_FUNDAMENTAL_CHAINLINK_ORACLE, "setDirectPrice(address,uint256)", bscmainnet.NORMAL_TIMELOCK],
+      },
+      {
+        target: SOLVBTC_FUNDAMENTAL_CHAINLINK_ORACLE,
+        signature: "setTokenConfigs((address,address,uint256)[])",
+        params: [[[SOLVBTC, FUNDAMENTAL_SOLVBTC_CONFIG.newFeed, FUNDAMENTAL_SOLVBTC_CONFIG.maxStalePeriod]]],
+      },
+      {
+        target: bscmainnet.CHAINLINK_ORACLE,
+        signature: "setTokenConfigs((address,address,uint256)[])",
+        params: [[[SOLVBTC, CHAINLINK_SOLVBTC_CONFIG.newFeed, CHAINLINK_SOLVBTC_CONFIG.maxStalePeriod]]],
+      },
+      {
+        target: bscmainnet.REDSTONE_ORACLE,
+        signature: "setTokenConfigs((address,address,uint256)[])",
+        params: [[[SOLVBTC, REDSTONE_SOLVBTC_CONFIG.newFeed, REDSTONE_SOLVBTC_CONFIG.maxStalePeriod]]],
+      },
+      {
+        target: bscmainnet.RESILIENT_ORACLE,
+        signature: "setTokenConfigs((address,address[3],bool[3],bool)[])",
+        params: [
+          [
+            [
+              SOLVBTC,
+              SOLVBTC_RESILIENT_ORACLE_CONFIG.new.oracles,
+              SOLVBTC_RESILIENT_ORACLE_CONFIG.new.enableFlagsForOracles,
+              SOLVBTC_RESILIENT_ORACLE_CONFIG.new.cachingEnabled,
+            ],
+          ],
+        ],
+      },
+
+      // ================================================================================
+      // ===== 2. U Oracle Update =====
+      // ================================================================================
+
+      {
+        target: ATLAS_ORACLE,
+        signature: "acceptOwnership()",
+        params: [],
+      },
+      {
+        target: bscmainnet.ACCESS_CONTROL_MANAGER,
+        signature: "giveCallPermission(address,string,address)",
+        params: [ATLAS_ORACLE, "setTokenConfig(TokenConfig)", bscmainnet.NORMAL_TIMELOCK],
+      },
+      {
+        target: bscmainnet.ACCESS_CONTROL_MANAGER,
+        signature: "giveCallPermission(address,string,address)",
+        params: [ATLAS_ORACLE, "setDirectPrice(address,uint256)", bscmainnet.NORMAL_TIMELOCK],
+      },
+      {
+        target: bscmainnet.CHAINLINK_ORACLE,
+        signature: "setTokenConfigs((address,address,uint256)[])",
+        params: [[[CHAINLINK_U_CONFIG.asset, CHAINLINK_U_CONFIG.newFeed, CHAINLINK_U_CONFIG.maxStalePeriod]]],
+      },
+      {
+        target: ATLAS_ORACLE,
+        signature: "setTokenConfigs((address,address,uint256)[])",
+        params: [[[ATLAS_U_CONFIG.asset, ATLAS_U_CONFIG.feed, ATLAS_U_CONFIG.maxStalePeriod]]],
+      },
+      {
+        target: bscmainnet.RESILIENT_ORACLE,
+        signature: "setTokenConfigs((address,address[3],bool[3],bool)[])",
+        params: [
+          [
+            [
+              U,
+              U_RESILIENT_ORACLE_CONFIG.new.oracles,
+              U_RESILIENT_ORACLE_CONFIG.new.enableFlagsForOracles,
+              U_RESILIENT_ORACLE_CONFIG.new.cachingEnabled,
+            ],
+          ],
+        ],
+      },
+
+      // ================================================================================
+      // ===== 3. XVS Base Reward Grant =====
+      // ================================================================================
+
+      {
+        target: bscmainnet.UNITROLLER,
+        signature: "_grantXVS(address,uint256)",
+        params: [XVS_STORE, XVS_GRANT_AMOUNT],
+      },
+    ],
+    meta,
+    ProposalType.REGULAR,
+  );
+};
+
+export default vip612;

--- a/vips/vip-612/bscmainnet.ts
+++ b/vips/vip-612/bscmainnet.ts
@@ -53,7 +53,7 @@ export const SOLVBTC_RESILIENT_ORACLE_CONFIG = {
       SOLVBTC_ONE_JUMP_CHAINLINK_ORACLE,
       SOLVBTC_ONE_JUMP_REDSTONE_ORACLE,
     ] as [string, string, string],
-    enableFlagsForOracles: [true, true, false] as [boolean, boolean, boolean],
+    enableFlagsForOracles: [true, true, true] as [boolean, boolean, boolean],
     cachingEnabled: false,
   },
 };
@@ -101,13 +101,21 @@ export const U_RESILIENT_ORACLE_CONFIG = {
 export const XVS_STORE = "0x1e25CF968f12850003Db17E0Dba32108509C4359";
 export const XVS_GRANT_AMOUNT = parseUnits("55875", 18);
 
+// ================================================================================
+// ===== Allez Labs Quarterly Payment =====
+// ================================================================================
+export const USDT = "0x55d398326f99059fF775485246999027B3197955";
+export const ALLEZ_LABS = "0x1757564C8C9a2c3cbE12620ea21B97d6E149F98e";
+export const ALLEZ_LABS_USDT_AMOUNT = parseUnits("105000", 18);
+
 export const vip612 = () => {
   const meta = {
     version: "v2",
-    title: "VIP-612 [BNB Chain] SolvBTC Oracle Setup + U Oracle Switch to Dedicated Feeds + XVS Base Reward Grant",
+    title:
+      "VIP-612 [BNB Chain] SolvBTC Oracle Setup + U Oracle Switch to Dedicated Feeds + XVS Base Reward Grant + Allez Labs Quarterly Payment",
     description: `## Summary
 
-This VIP performs three independent actions on BNB Chain:
+This VIP performs four independent actions on BNB Chain:
 
 ### 1. SolvBTC Oracle Setup
 
@@ -115,7 +123,7 @@ Configures a three-tier resilient oracle for SolvBTC/USD pricing using the OneJu
 (SolvBTC/BTC rate × BTCB/USD = SolvBTC/USD):
 - **MAIN**: CorrelatedTokenOracle (SolvBTCOneJumpFundamentalOracle) using the Solv self-reported fundamental rate
 - **PIVOT**: OneJumpOracle (SolvBTCOneJumpChainlinkOracle) using the Chainlink ER feed
-- **FALLBACK**: OneJumpOracle (SolvBTCOneJumpRedStoneOracle) using the RedStone cross-market feed (disabled)
+- **FALLBACK**: OneJumpOracle (SolvBTCOneJumpRedStoneOracle) using the RedStone cross-market feed
 
 Also grants ACM permissions to the Normal Timelock for the freshly deployed SolvBTCFundamentalChainlinkOracle.
 
@@ -138,7 +146,11 @@ Outstanding amounts:
 - Q2 2026: 91 days × 308.7 = 28,092 XVS
 - Total: 55,875 XVS
 
-This VIP calls _grantXVS on the Core Pool Comptroller to transfer 55,875 XVS directly to XVSStore.`,
+This VIP calls _grantXVS on the Core Pool Comptroller to transfer 55,875 XVS directly to XVSStore.
+
+### 4. Allez Labs Quarterly Payment
+
+Transfers 105,000 USDT from the Venus Treasury to Allez Labs (0x1757564C8C9a2c3cbE12620ea21B97d6E149F98e) as their quarterly payment.`,
     forDescription: "I agree that Venus Protocol should proceed with this proposal",
     againstDescription: "I do not think that Venus Protocol should proceed with this proposal",
     abstainDescription: "I am indifferent to whether Venus Protocol proceeds or not",
@@ -247,6 +259,16 @@ This VIP calls _grantXVS on the Core Pool Comptroller to transfer 55,875 XVS dir
         target: bscmainnet.UNITROLLER,
         signature: "_grantXVS(address,uint256)",
         params: [XVS_STORE, XVS_GRANT_AMOUNT],
+      },
+
+      // ================================================================================
+      // ===== 4. Allez Labs Quarterly Payment =====
+      // ================================================================================
+
+      {
+        target: bscmainnet.VTREASURY,
+        signature: "withdrawTreasuryBEP20(address,uint256,address)",
+        params: [USDT, ALLEZ_LABS_USDT_AMOUNT, ALLEZ_LABS],
       },
     ],
     meta,

--- a/vips/vip-612/bscmainnet.ts
+++ b/vips/vip-612/bscmainnet.ts
@@ -113,9 +113,9 @@ This VIP performs three independent actions on BNB Chain:
 
 Configures a three-tier resilient oracle for SolvBTC/USD pricing using the OneJump pattern
 (SolvBTC/BTC rate × BTCB/USD = SolvBTC/USD):
-- **MAIN**: OneJumpOracle (SolvBTCOneJumpRedStoneOracle) using the RedStone cross-market feed
+- **MAIN**: CorrelatedTokenOracle (SolvBTCOneJumpFundamentalOracle) using the Solv self-reported fundamental rate
 - **PIVOT**: OneJumpOracle (SolvBTCOneJumpChainlinkOracle) using the Chainlink ER feed
-- **FALLBACK**: CorrelatedTokenOracle (SolvBTCOneJumpFundamentalOracle) using the Solv self-reported fundamental feed
+- **FALLBACK**: OneJumpOracle (SolvBTCOneJumpRedStoneOracle) using the RedStone cross-market feed (disabled)
 
 Also grants ACM permissions to the Normal Timelock for the freshly deployed SolvBTCFundamentalChainlinkOracle.
 


### PR DESCRIPTION
## VIP-612: 2026 Week 16 VIP: solvBTC & U Oracle Upgrades, Allez Labs Q2 Payment & XVS Vault Base Reward Top-up

## Context

1. solvBTC Oracle: [VPD-995](https://venus-labs.atlassian.net/browse/VPD-995)
2. U Oracle: [VPD-996](https://venus-labs.atlassian.net/browse/VPD-996)
3. Allez Labs Q2 payment, ref [VIP-594](https://app.venus.io/#/governance/proposal/594?chainId=56)
4. XVS Vault base reward top-up: [VPD-1024](https://venus-labs.atlassian.net/browse/VPD-1024)

---

## Title

2026 Week 16 VIP: solvBTC & U Oracle Upgrades, Allez Labs Q2 Payment & XVS Vault Base Reward Top-up

## Summary

This VIP bundles four protocol actions on BNB Chain:

1. **Switch solvBTC oracle** from RedStone market price feed to a manipulation-resistant CorrelatedTokenOracle (RedStone exchange rate feed), replace BinanceOracle PIVOT with Chainlink Exchange Rate feed, and add a RedStone cross-market FALLBACK — upgrading from Tier 2 to Full (3 oracles).
2. **Switch U oracle** from non-dedicated Chainlink USDT/USD1 feeds to dedicated Chainlink U/USD (MAIN) and Atlas U/USD (PIVOT) feeds.
3. **Transfer $105,000 USDT** from Venus Treasury to Allez Labs for Q2 2026 risk management services.
4. **Fund XVS Vault base rewards** by calling `_grantXVS` to transfer ~55,875 XVS from the Core Pool Comptroller to the XVS Store, covering Q1–Q2 2026.

## Description

### 1. [BNB Chain] solvBTC Oracle Switch to Exchange Rate Feed

**Context**
solvBTC has low spot trading volume on BSC DEXs, making the current RedStone market price feed vulnerable to manipulation. Solv has requested switching to exchange rate feeds. Chainlink ER feed is now live on BNB Chain.

**Current Configuration**

| Role     | Oracle         | Feed                        | Deviation | Heartbeat | max_stale |
| -------- | -------------- | --------------------------- | --------- | --------- | --------- |
| MAIN     | RedStoneOracle | RS:SolvBTC (0xF5F6...a550)  | 0.5%      | 6h        | 21,900s   |
| PIVOT    | BinanceOracle  | BN:SOLVBTC                  | 1.0%      | 12h       | 43,500s   |
| FALLBACK | N/A            | —                           | —         | —         | —         |

**Proposed Configuration**

| Role     | Oracle                 | Feed                                                                                                     | Address                                    | Deviation | Heartbeat | max_stale |
| -------- | ---------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------ | --------- | --------- | --------- |
| MAIN     | CorrelatedTokenOracle  | [RS:SolvBTC_FUNDAMENTAL](https://app.redstone.finance/app/feeds/bnb-chain/solvbtc_fundamental/)          | 0x77471661568DC65d4574EAd9544DfF1e618Adfb2 | 0.01%     | 24h       | 86,700s   |
| PIVOT    | ChainlinkOracle        | CL:solvBTC/BTC Exchange Rate                                                                             | 0xf93b9B23c46331704EC550c24CB4110975057863 | 1.0%      | 24h       | 86,700s   |
| FALLBACK | RedStoneOracle         | SolvBTC/BTC cross-market (~14 CEX)                                                                       | 0x8D89d6c114193154f111D7C83299D285C9cC5BBC | 0.5%      | 6h        | 21,900s   |

Tier: Full (MAIN + PIVOT + FALLBACK)

**Key Changes**

- MAIN: RedStone SolvBTC_FUNDAMENTAL exchange rate feed via CorrelatedTokenOracle — immune to spot market manipulation
- PIVOT: Chainlink solvBTC/BTC Exchange Rate feed — replaces BinanceOracle to align with Solv's migration away from market rate feeds
- FALLBACK: RedStone cross-market feed aggregating ~14 CEX sources — provides market price backup
- max_stale = provider heartbeat + 300s (consistent with protocol-wide oracle audit recommendation)

**Actions**

- Configure CorrelatedTokenOracle for solvBTC with SolvBTC_FUNDAMENTAL feed
- Set MAIN oracle to CorrelatedTokenOracle, max_stale = 86,700s
- Set PIVOT oracle to ChainlinkOracle with solvBTC/BTC ER feed, max_stale = 86,700s
- Configure FALLBACK oracle to RedStoneOracle with SolvBTC/BTC cross-market feed, max_stale = 21,900s

### 2. [BNB Chain] U Oracle — Switch to Dedicated Feeds

**Context**
Venus currently prices U using non-dedicated oracles (Chainlink USDT and USD1 as proxies). Both Chainlink and Atlas (formerly CMC) have now deployed dedicated U/USD feeds on BNB Chain.

**Current Configuration**

| Role     | Oracle                   | Feed                                           | Address                                    | max_stale |
| -------- | ------------------------ | ---------------------------------------------- | ------------------------------------------ | --------- |
| MAIN     | ChainlinkOracle (capped) | Stabilized USDT Price Feed (non-dedicated)     | 0xF884002406Ac6Fd93FF5C989506220f781A97eEA | 100s      |
| PIVOT    | ChainlinkOracle          | USD1/USD (non-dedicated)                       | —                                          | 86,700s   |
| FALLBACK | N/A                      | —                                              | —                                          | —         |

Tier: 2 (MAIN + PIVOT only)

**Proposed Configuration**

| Role  | Oracle                | Feed                                                                                                   | Address                                    | Deviation | Heartbeat | max_stale |
| ----- | --------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------ | --------- | --------- | --------- |
| MAIN  | ChainlinkOracle       | [U/USD (dedicated)](https://data.chain.link/feeds/bsc/mainnet/u-usd)                                   | 0x2Ab73dc1C8A23bcDDb4850Ff811850E0d2a0c72f | 0.5%      | 24h       | 86,700s   |
| PIVOT | Atlas (formerly CMC)  | [U/USD (dedicated)](https://bscscan.com/address/0x14a20eafffada4d78afeef1185e7317cf98f6a1f)            | 0x14a20eafffada4d78afeef1185e7317cf98f6a1f | 0.5%      | 24h       | 86,700s   |

Tier: 2 (MAIN + PIVOT)

**Actions**

- Set MAIN oracle to ChainlinkOracle with dedicated U/USD feed, max_stale = 86,700s
- Set PIVOT oracle to Atlas with dedicated U/USD feed, max_stale = 86,700s

### 3. [BNB Chain] Allez Labs Q2 2026 Risk Services Payment

**Context**
Allez Labs provides risk management services to Venus Protocol. Per the contract terms, fees are paid quarterly in advance starting Q2 2026. This is the payment covering Q2 2026 (26 April 2026 – 25 July 2026).

**Transfer Details**

| Item        | Details                                                               |
| ----------- | --------------------------------------------------------------------- |
| Amount      | 105,000 USDT                                                          |
| Source      | Venus Treasury (0xf322942f644a996a617bd29c16bd7d231d9f35e9)           |
| Destination | Allez Labs (0x1757564C8C9a2c3cbE12620ea21B97d6E149F98e)               |
| Period      | Q2 2026 (April – July)                                                |
| Basis       | $35,000/month × 3 months                                              |

**Actions**

- Direct Transfer 105,000 USDT from Venus Treasury to Allez Labs at 0x1757564C8C9a2c3cbE12620ea21B97d6E149F98e

### 4. [BNB Chain] Fund XVS Vault Base Rewards for H1 2026

The fixed Base Reward allocation of 308.7 XVS/day on BNB Chain has not been funded from the Core Pool Comptroller since [VIP-529](https://app.venus.io/#/governance/proposal/529?chainId=56) (July 2025), which only covered through 2025-12-31. Both Q1 and Q2 2026 base rewards are outstanding.

**Outstanding Amount**

- Q1 2026: 90 days × 308.7 = 27,783 XVS
- Q2 2026: 91 days × 308.7 = 28,092 XVS
- Total: ~55,875 XVS

**Actions**

- Call `_grantXVS(XVS_STORE, ~55,875)` on the Core Pool Comptroller to transfer XVS to the [XVS Store](https://bscscan.com/address/0x1e25CF968f12850003Db17E0Dba32108509C4359)

## Voting options

- **For** — Execute this proposal
- **Against** — Do not execute this proposal
- **Abstain** — Indifferent to execution


[VPD-995]: https://venus-labs.atlassian.net/browse/VPD-995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPD-996]: https://venus-labs.atlassian.net/browse/VPD-996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPD-1024]: https://venus-labs.atlassian.net/browse/VPD-1024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ