### PR TITLE
[VPD-1185] feat: update TokenBuyback  bsctestnet vip

### DIFF
--- a/simulations/vip-618/bsctestnet.ts
+++ b/simulations/vip-618/bsctestnet.ts
@@ -1,5 +1,4 @@
 import { expect } from "chai";
-import { BigNumber } from "ethers";
 import { ethers } from "hardhat";
 import { NETWORK_ADDRESSES } from "src/networkAddresses";
 import { forking, testVip } from "src/vip-framework";
@@ -7,40 +6,31 @@ import { forking, testVip } from "src/vip-framework";
 import vip618, {
   BUYBACKS,
   DEFAULT_PROXY_ADMIN,
+  LEGACY_CONVERTERS,
   NEW_RISK_FUND_V2_IMPL,
-  OPERATOR,
-  PANCAKE_ROUTER,
-  PROTOCOL_SHARE_RESERVE,
   RISK_FUND_V2,
   SHORTFALL,
-  USDT,
 } from "../../vips/vip-618/bsctestnet";
-import ACM_ABI from "./abi/AccessControlManager.json";
 import DEFAULT_PROXY_ADMIN_ABI from "./abi/DefaultProxyAdmin.json";
-import ERC20_ABI from "./abi/ERC20.json";
-import PSR_ABI from "./abi/ProtocolShareReserve.json";
+import SINGLE_TOKEN_CONVERTER_ABI from "./abi/SingleTokenConverter.json";
 import BUYBACK_ABI from "./abi/TokenBuyback.json";
 
 const { bsctestnet } = NETWORK_ADDRESSES;
 
-// TODO
-const FORK_BLOCK = 0;
+const FORK_BLOCK = 106811121;
 
 const SHORTFALL_MIN_ABI = ["function auctionsPaused() view returns (bool)"];
 
 forking(FORK_BLOCK, async () => {
-  const acm = new ethers.Contract(bsctestnet.ACCESS_CONTROL_MANAGER, ACM_ABI, ethers.provider);
   const proxyAdmin = new ethers.Contract(DEFAULT_PROXY_ADMIN, DEFAULT_PROXY_ADMIN_ABI, ethers.provider);
-  const psr = new ethers.Contract(PROTOCOL_SHARE_RESERVE, PSR_ABI, ethers.provider);
-  const usdt = new ethers.Contract(USDT, ERC20_ABI, ethers.provider);
   const shortfall = new ethers.Contract(SHORTFALL, SHORTFALL_MIN_ABI, ethers.provider);
 
-  let riskFundV2UsdtBalanceBefore: BigNumber;
   let shortfallAuctionsPausedBefore: boolean;
+  let riskFundV2ImplBefore: string;
 
   before(async () => {
-    riskFundV2UsdtBalanceBefore = await usdt.balanceOf(RISK_FUND_V2);
     shortfallAuctionsPausedBefore = await shortfall.auctionsPaused();
+    riskFundV2ImplBefore = await proxyAdmin.getProxyImplementation(RISK_FUND_V2);
   });
 
   describe("Pre-VIP state", () => {
@@ -51,23 +41,14 @@ forking(FORK_BLOCK, async () => {
       }
     });
 
-    it("PancakeSwap router is not yet allowlisted on buybacks", async () => {
-      for (const b of BUYBACKS) {
-        const buyback = new ethers.Contract(b, BUYBACK_ABI, ethers.provider);
-        expect(await buyback.allowedRouters(PANCAKE_ROUTER)).to.be.false;
-      }
+    it("RiskFundV2 currently points at the old implementation", async () => {
+      expect(riskFundV2ImplBefore).to.not.equal(NEW_RISK_FUND_V2_IMPL);
     });
 
-    it("operator has no executeBuyback / forwardBaseAsset grants yet", async () => {
-      for (const b of BUYBACKS) {
-        expect(
-          await acm.isAllowedToCall(
-            OPERATOR,
-            b,
-            "executeBuyback(address,uint256,uint256,uint256,address,bytes,address)",
-          ),
-        ).to.be.false;
-        expect(await acm.isAllowedToCall(OPERATOR, b, "forwardBaseAsset(address,uint256)")).to.be.false;
+    it("legacy converters are not yet paused", async () => {
+      for (const c of LEGACY_CONVERTERS) {
+        const converter = new ethers.Contract(c, SINGLE_TOKEN_CONVERTER_ABI, ethers.provider);
+        expect(await converter.conversionPaused()).to.be.false;
       }
     });
 
@@ -78,9 +59,13 @@ forking(FORK_BLOCK, async () => {
     });
   });
 
-  testVip("VIP-618 [BNB Chain Testnet] TokenBuyback Migration & May Prime Allocation", await vip618());
+  testVip("VIP-618 [BNB Chain Testnet] TokenBuyback Migration", await vip618());
 
   describe("Post-VIP state", () => {
+    it("RiskFundV2 proxy upgraded to new implementation", async () => {
+      expect(await proxyAdmin.getProxyImplementation(RISK_FUND_V2)).to.equal(NEW_RISK_FUND_V2_IMPL);
+    });
+
     it("NormalTimelock owns each buyback proxy", async () => {
       for (const b of BUYBACKS) {
         const buyback = new ethers.Contract(b, BUYBACK_ABI, ethers.provider);
@@ -88,53 +73,11 @@ forking(FORK_BLOCK, async () => {
       }
     });
 
-    it("PancakeSwap V2 router allowlisted on each buyback", async () => {
-      for (const b of BUYBACKS) {
-        const buyback = new ethers.Contract(b, BUYBACK_ABI, ethers.provider);
-        expect(await buyback.allowedRouters(PANCAKE_ROUTER)).to.be.true;
+    it("each legacy converter is paused", async () => {
+      for (const c of LEGACY_CONVERTERS) {
+        const converter = new ethers.Contract(c, SINGLE_TOKEN_CONVERTER_ABI, ethers.provider);
+        expect(await converter.conversionPaused()).to.be.true;
       }
-    });
-
-    it("operator granted executeBuyback + forwardBaseAsset on each buyback", async () => {
-      for (const b of BUYBACKS) {
-        expect(
-          await acm.isAllowedToCall(
-            OPERATOR,
-            b,
-            "executeBuyback(address,uint256,uint256,uint256,address,bytes,address)",
-          ),
-        ).to.be.true;
-        expect(await acm.isAllowedToCall(OPERATOR, b, "forwardBaseAsset(address,uint256)")).to.be.true;
-      }
-    });
-
-    it("RiskFundV2 proxy upgraded to new implementation", async () => {
-      expect(await proxyAdmin.getProxyImplementation(RISK_FUND_V2)).to.equal(NEW_RISK_FUND_V2_IMPL);
-    });
-
-    it("RiskFundV2 USDT balance non-decreasing across upgrade", async () => {
-      // New impl keeps funds physically in the contract (no migration).
-      const after = await usdt.balanceOf(RISK_FUND_V2);
-      expect(after).to.be.gte(riskFundV2UsdtBalanceBefore);
-    });
-
-    // TODO: enumerate PSR.distributionTargets(i) and assert each of the 10 new buybacks
-    //       is a destination, no legacy converter remains, and percentages sum to 1e4
-    //       per schema. Placeholder assertion below; flesh out after PSR rows filled.
-    it("PSR distribution configs repointed", async () => {
-      // Example shape — iterate until the getter reverts to enumerate:
-      //   const rows = [];
-      //   for (let i = 0; ; i++) {
-      //     try { rows.push(await psr.distributionTargets(i)); } catch { break; }
-      //   }
-      //   expect(rows.map(r => r.destination)).to.include.members(BUYBACKS);
-      void psr;
-    });
-
-    // TODO: legacy converter residual balances == 0 for drained tokens
-    //       (skipped on testnet if amounts are below gas-worth per PRD note).
-    it("legacy converter balances drained", async () => {
-      // TODO
     });
 
     it("Shortfall auctions are paused (defense in depth)", async () => {

--- a/simulations/vip-618/bsctestnet.ts
+++ b/simulations/vip-618/bsctestnet.ts
@@ -1,16 +1,23 @@
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { NETWORK_ADDRESSES } from "src/networkAddresses";
+import { initMainnetUser } from "src/utils";
 import { forking, testVip } from "src/vip-framework";
 
 import vip618, {
   BUYBACKS,
   DEFAULT_PROXY_ADMIN,
+  EXECUTE_BUYBACK_SIG,
+  FORWARD_BASE_ASSET_SIG,
   LEGACY_CONVERTERS,
   NEW_RISK_FUND_V2_IMPL,
+  OPERATOR,
   RISK_FUND_V2,
+  SET_DAILY_CAP_USD_SIG,
+  SET_SLIPPAGE_EVENT_USD_SIG,
   SHORTFALL,
 } from "../../vips/vip-618/bsctestnet";
+import ACM_ABI from "./abi/AccessControlManager.json";
 import DEFAULT_PROXY_ADMIN_ABI from "./abi/DefaultProxyAdmin.json";
 import SINGLE_TOKEN_CONVERTER_ABI from "./abi/SingleTokenConverter.json";
 import BUYBACK_ABI from "./abi/TokenBuyback.json";
@@ -22,6 +29,7 @@ const FORK_BLOCK = 106811121;
 const SHORTFALL_MIN_ABI = ["function auctionsPaused() view returns (bool)"];
 
 forking(FORK_BLOCK, async () => {
+  const acm = new ethers.Contract(bsctestnet.ACCESS_CONTROL_MANAGER, ACM_ABI, ethers.provider);
   const proxyAdmin = new ethers.Contract(DEFAULT_PROXY_ADMIN, DEFAULT_PROXY_ADMIN_ABI, ethers.provider);
   const shortfall = new ethers.Contract(SHORTFALL, SHORTFALL_MIN_ABI, ethers.provider);
 
@@ -52,6 +60,24 @@ forking(FORK_BLOCK, async () => {
       }
     });
 
+    it("operator has no executeBuyback / forwardBaseAsset grants yet", async () => {
+      for (const b of BUYBACKS) {
+        const buybackSigner = await initMainnetUser(b, ethers.utils.parseEther("1"));
+        expect(await acm.connect(buybackSigner).isAllowedToCall(OPERATOR, EXECUTE_BUYBACK_SIG)).to.be.false;
+        expect(await acm.connect(buybackSigner).isAllowedToCall(OPERATOR, FORWARD_BASE_ASSET_SIG)).to.be.false;
+      }
+    });
+
+    it("NormalTimelock has no setDailyCapUsd / setSlippageEventUsd grants yet", async () => {
+      for (const b of BUYBACKS) {
+        const buybackSigner = await initMainnetUser(b, ethers.utils.parseEther("1"));
+        expect(await acm.connect(buybackSigner).isAllowedToCall(bsctestnet.NORMAL_TIMELOCK, SET_DAILY_CAP_USD_SIG)).to
+          .be.false;
+        expect(await acm.connect(buybackSigner).isAllowedToCall(bsctestnet.NORMAL_TIMELOCK, SET_SLIPPAGE_EVENT_USD_SIG))
+          .to.be.false;
+      }
+    });
+
     it("captures Shortfall.auctionsPaused() pre-state (informational)", async () => {
       // No assertion on the pre-state: isolated pools are wound down so the flag
       // could be either value depending on prior governance actions.
@@ -77,6 +103,32 @@ forking(FORK_BLOCK, async () => {
       for (const c of LEGACY_CONVERTERS) {
         const converter = new ethers.Contract(c, SINGLE_TOKEN_CONVERTER_ABI, ethers.provider);
         expect(await converter.conversionPaused()).to.be.true;
+      }
+    });
+
+    it("operator granted executeBuyback + forwardBaseAsset on each buyback", async () => {
+      for (const b of BUYBACKS) {
+        const buybackSigner = await initMainnetUser(b, ethers.utils.parseEther("1"));
+        expect(await acm.connect(buybackSigner).isAllowedToCall(OPERATOR, EXECUTE_BUYBACK_SIG), `${b}/executeBuyback`)
+          .to.be.true;
+        expect(
+          await acm.connect(buybackSigner).isAllowedToCall(OPERATOR, FORWARD_BASE_ASSET_SIG),
+          `${b}/forwardBaseAsset`,
+        ).to.be.true;
+      }
+    });
+
+    it("NormalTimelock granted setDailyCapUsd + setSlippageEventUsd on each buyback", async () => {
+      for (const b of BUYBACKS) {
+        const buybackSigner = await initMainnetUser(b, ethers.utils.parseEther("1"));
+        expect(
+          await acm.connect(buybackSigner).isAllowedToCall(bsctestnet.NORMAL_TIMELOCK, SET_DAILY_CAP_USD_SIG),
+          `${b}/setDailyCapUsd`,
+        ).to.be.true;
+        expect(
+          await acm.connect(buybackSigner).isAllowedToCall(bsctestnet.NORMAL_TIMELOCK, SET_SLIPPAGE_EVENT_USD_SIG),
+          `${b}/setSlippageEventUsd`,
+        ).to.be.true;
       }
     });
 

--- a/vips/vip-618/bsctestnet.ts
+++ b/vips/vip-618/bsctestnet.ts
@@ -1,4 +1,3 @@
-import { ethers } from "ethers";
 import { ProposalType } from "src/types";
 import { makeProposal } from "src/utils";
 
@@ -6,18 +5,15 @@ export const DEFAULT_PROXY_ADMIN = "0x7877ffd62649b6a1557b55d4c20fcbab17344c91";
 export const RISK_FUND_V2 = "0x487CeF72dacABD7E12e633bb3B63815a386f7012";
 export const SHORTFALL = "0x503574a82fE2A9f968d355C8AAc1Ba0481859369";
 
-// ===== Legacy converters =====
+// ===== Legacy converters (timelock-owned, paused in this VIP) =====
+// WBNBBurnConverter is guardian-owned and intentionally not paused here.
 export const RISK_FUND_CONVERTER = "0x32Fbf7bBbd79355B86741E3181ef8c1D9bD309Bb";
 export const USDT_PRIME_CONVERTER = "0xf1FA230D25fC5D6CAfe87C5A6F9e1B17Bc6F194E";
 export const USDC_PRIME_CONVERTER = "0x2ecEdE6989d8646c992344fF6C97c72a3f811A13";
 export const BTCB_PRIME_CONVERTER = "0x989A1993C023a45DA141928921C0dE8fD123b7d1";
 export const ETH_PRIME_CONVERTER = "0xf358650A007aa12ecC8dac08CF8929Be7f72A4D9";
 export const XVS_VAULT_CONVERTER = "0x258f49254C758a0E37DAb148ADDAEA851F4b02a2";
-// WBNBBurnConverter is guardian-owned — not paused by this VIP (mirrors mainnet helper behaviour).
-export const WBNB_BURN_CONVERTER = "0x42DBA48e7cCeB030eC73AaAe29d4A3F0cD4facba";
-export const CONVERTER_NETWORK = "0xC8f2B705d5A2474B390f735A5aFb570e1ce0b2cf";
 
-// Timelock-owned converters that are paused in this VIP (6 — excludes WBNB_BURN_CONVERTER).
 export const LEGACY_CONVERTERS: string[] = [
   RISK_FUND_CONVERTER,
   USDT_PRIME_CONVERTER,
@@ -27,7 +23,7 @@ export const LEGACY_CONVERTERS: string[] = [
   XVS_VAULT_CONVERTER,
 ];
 
-// ===== New TokenBuyback proxies — TODO: fill from deploy on feat/VPD-1087 =====
+// ===== New TokenBuyback proxies =====
 export const RISK_FUND_BUYBACK = "0x1a063a07853b9bC797E571E54B5Ce632195071fE";
 export const USDT_PRIME_BUYBACK = "0xaAc507Ae5BF60d94e15489fcF75C3AB9D3C6ab55";
 export const U_PRIME_BUYBACK = "0xa9f091C50C2Bd214F757DAF243bCb94A9fE707a4";
@@ -57,30 +53,21 @@ export const NEW_RISK_FUND_V2_IMPL = "0xAAe9c6412A7EaeB82eD2bA8E9E2bBc27bDa921f6
 export const vip618 = () => {
   const meta = {
     version: "v2",
-    title: "VIP-618 [BNB Chain Testnet] TokenBuyback Migration & May Prime Allocation",
+    title: "VIP-618 [BNB Chain Testnet] TokenBuyback Migration",
     description: `#### Summary
 
-If passed, this VIP replaces the community-driven Token Converter system (RiskFundConverter + 4 *PrimeConverter + XVSVaultConverter + WBNBBurnConverter + ConverterNetwork) with **10 ACM-authorized TokenBuyback proxies** driven by a finance-team cron. BSC-only; this VIP targets **BNB Chain Testnet**.
+If passed, this VIP retires the legacy Token Converter system on **BNB Chain Testnet** and hands the ten new TokenBuyback proxies to NormalTimelock. This is the **only** VIP-618 action on BNB Chain Testnet — there is no follow-up. Router allowlisting, ACM operator grants on the new buybacks, draining of legacy converters, ACM revocations on legacy converters, and the repointing of \`ProtocolShareReserve\` distribution configs will **not** happen on testnet.
 
 #### Proposed Changes
 
-1. **Upgrade RiskFundV2 implementation** — new impl removes \`updatePoolState\`, \`sweepTokenFromPool\`, and the \`poolAssetsFunds\` mapping (storage slot preserved as \`__deprecatedSlotPoolAssetsFunds\`). \`transferReserveForAuction\` now reads raw balance.
-2. **Accept ownership** on each of the 10 new buyback proxies (deploy script already called \`transferOwnership(NormalTimelock)\`).
-3. **Allowlist PancakeSwap V2 router** on each of the 10 buybacks.
-4. **Grant ACM permissions** on \`executeBuyback\` + \`forwardBaseAsset\` for the cron operator on each of the 10 buybacks.
-5. **Drain legacy converters** (remaining tokens → new buyback or VTreasury).
-6. **Revoke ACM permissions** on legacy converters.
-7. **Repoint ProtocolShareReserve distributions** from legacy converters to the 10 new buybacks.
-8. **Defensively call \`Shortfall.pauseAuctions()\`** to keep the auction surface closed post-upgrade. Isolated pools are wound down on testnet as on mainnet — no live or upcoming auctions exist, so this is purely defense in depth.
+1. **Pause legacy converters** — call \`pauseConversion()\` on each of the six timelock-owned converters (RiskFundConverter + four \`*PrimeConverter\` + XVSVaultConverter). WBNBBurnConverter is guardian-owned and is not touched by this VIP.
+2. **Upgrade RiskFundV2 implementation** — new impl removes \`updatePoolState\`, \`sweepTokenFromPool\`, and the \`poolAssetsFunds\` mapping (storage slot preserved as \`__deprecatedSlotPoolAssetsFunds\`). \`transferReserveForAuction\` now reads raw balance.
+3. **Accept ownership** on each of the ten new TokenBuyback proxies (deploy script already called \`transferOwnership(NormalTimelock)\`).
+4. **Pause Shortfall auctions** as defense in depth post-upgrade. Isolated pools are wound down on testnet — no live or upcoming auctions exist.
 
-RiskFundConverter drain + revoke is ordered **before** the upgrade — new impl removes \`updatePoolState\`, so in-flight \`convertExactTokens\` callbacks would revert.
+The pause step runs **before** the RiskFundV2 upgrade so that RiskFundConverter cannot enter \`convertExactTokens\` against the new impl (which no longer exposes \`updatePoolState\`) between transactions outside this proposal.
 
-Implementation: [VenusProtocol/protocol-reserve PR #158](https://github.com/VenusProtocol/protocol-reserve/pull/158).
-
-#### Retired contracts
-
-- WBNBBurnConverter — protocol shifted away from buy-and-burn.
-- ConverterNetwork — routing layer no longer needed with direct PSR → Buyback wiring.`,
+Implementation: [VenusProtocol/protocol-reserve PR #158](https://github.com/VenusProtocol/protocol-reserve/pull/158).`,
     forDescription: "I agree that Venus Protocol should proceed with this proposal",
     againstDescription: "I do not think that Venus Protocol should proceed with this proposal",
     abstainDescription: "I am indifferent to whether Venus Protocol proceeds or not",
@@ -88,24 +75,24 @@ Implementation: [VenusProtocol/protocol-reserve PR #158](https://github.com/Venu
 
   return makeProposal(
     [
-      // 1. Upgrade RiskFundV2 implementation
+      // 1. Pause legacy timelock-owned converters (RiskFundConverter first protects RiskFundV2 upgrade)
+      ...LEGACY_CONVERTERS.map(c => ({
+        target: c,
+        signature: "pauseConversion()",
+        params: [],
+      })),
+
+      // 2. Upgrade RiskFundV2 implementation
       {
         target: DEFAULT_PROXY_ADMIN,
         signature: "upgrade(address,address)",
         params: [RISK_FUND_V2, NEW_RISK_FUND_V2_IMPL],
       },
 
-      // 2. Accept ownership of 10 TokenBuyback proxies
+      // 3. Accept ownership of 10 TokenBuyback proxies
       ...BUYBACKS.map(b => ({
         target: b,
         signature: "acceptOwnership()",
-        params: [],
-      })),
-
-      // 3. Retire legacy converters — pause conversions (mirrors helper _pauseAllTimelockOwnedConverters)
-      ...LEGACY_CONVERTERS.map(c => ({
-        target: c,
-        signature: "pauseConversion()",
         params: [],
       })),
 

--- a/vips/vip-618/bsctestnet.ts
+++ b/vips/vip-618/bsctestnet.ts
@@ -1,18 +1,36 @@
+import { NETWORK_ADDRESSES } from "src/networkAddresses";
 import { ProposalType } from "src/types";
 import { makeProposal } from "src/utils";
+
+const { bsctestnet } = NETWORK_ADDRESSES;
 
 export const DEFAULT_PROXY_ADMIN = "0x7877ffd62649b6a1557b55d4c20fcbab17344c91";
 export const RISK_FUND_V2 = "0x487CeF72dacABD7E12e633bb3B63815a386f7012";
 export const SHORTFALL = "0x503574a82fE2A9f968d355C8AAc1Ba0481859369";
 
-// ===== Legacy converters (timelock-owned, paused in this VIP) =====
-// WBNBBurnConverter is guardian-owned and intentionally not paused here.
+// Multisig acting as buyback cron operator on testnet (same Safe used as GUARDIAN / default proposer).
+export const OPERATOR = bsctestnet.GUARDIAN;
+
+// Operator (cron) signatures — granted to the multisig OPERATOR.
+export const EXECUTE_BUYBACK_SIG = "executeBuyback(address,uint256,uint256,uint256,address,bytes,address)";
+export const FORWARD_BASE_ASSET_SIG = "forwardBaseAsset(address,uint256)";
+
+// Admin/config signatures — ACM-gated; granted to NormalTimelock so governance can tune buyback config
+// without further VIPs. (setAllowedRouter and sweepToken are onlyOwner on TokenBuyback, not ACM-gated,
+// so they need no grant — NormalTimelock owns each buyback proxy and can call them directly.)
+export const SET_DAILY_CAP_USD_SIG = "setDailyCapUsd(uint256)";
+export const SET_SLIPPAGE_EVENT_USD_SIG = "setSlippageEventUsd(uint256)";
+
+// ===== Legacy converters (NormalTimelock-owned on bsctestnet, paused in this VIP) =====
+// Note: on mainnet WBNBBurnConverter is Guardian-owned and excluded by the migration helper,
+// but on bsctestnet it is NormalTimelock-owned (verified on-chain), so we include it here.
 export const RISK_FUND_CONVERTER = "0x32Fbf7bBbd79355B86741E3181ef8c1D9bD309Bb";
 export const USDT_PRIME_CONVERTER = "0xf1FA230D25fC5D6CAfe87C5A6F9e1B17Bc6F194E";
 export const USDC_PRIME_CONVERTER = "0x2ecEdE6989d8646c992344fF6C97c72a3f811A13";
 export const BTCB_PRIME_CONVERTER = "0x989A1993C023a45DA141928921C0dE8fD123b7d1";
 export const ETH_PRIME_CONVERTER = "0xf358650A007aa12ecC8dac08CF8929Be7f72A4D9";
 export const XVS_VAULT_CONVERTER = "0x258f49254C758a0E37DAb148ADDAEA851F4b02a2";
+export const WBNB_BURN_CONVERTER = "0x42DBA48e7cCeB030eC73AaAe29d4A3F0cD4facba";
 
 export const LEGACY_CONVERTERS: string[] = [
   RISK_FUND_CONVERTER,
@@ -21,6 +39,7 @@ export const LEGACY_CONVERTERS: string[] = [
   BTCB_PRIME_CONVERTER,
   ETH_PRIME_CONVERTER,
   XVS_VAULT_CONVERTER,
+  WBNB_BURN_CONVERTER,
 ];
 
 // ===== New TokenBuyback proxies =====
@@ -56,14 +75,21 @@ export const vip618 = () => {
     title: "VIP-618 [BNB Chain Testnet] TokenBuyback Migration",
     description: `#### Summary
 
-If passed, this VIP retires the legacy Token Converter system on **BNB Chain Testnet** and hands the ten new TokenBuyback proxies to NormalTimelock. This is the **only** VIP-618 action on BNB Chain Testnet — there is no follow-up. Router allowlisting, ACM operator grants on the new buybacks, draining of legacy converters, ACM revocations on legacy converters, and the repointing of \`ProtocolShareReserve\` distribution configs will **not** happen on testnet.
+If passed, this VIP retires the legacy Token Converter system on **BNB Chain Testnet** and hands the ten new TokenBuyback proxies to NormalTimelock. This is the **only** VIP-618 action on BNB Chain Testnet — there is no follow-up. Router allowlisting, draining of legacy converters, ACM revocations on legacy converters, and the repointing of \`ProtocolShareReserve\` distribution configs will **not** happen on testnet.
 
 #### Proposed Changes
 
-1. **Pause legacy converters** — call \`pauseConversion()\` on each of the six timelock-owned converters (RiskFundConverter + four \`*PrimeConverter\` + XVSVaultConverter). WBNBBurnConverter is guardian-owned and is not touched by this VIP.
+1. **Pause legacy converters** — call \`pauseConversion()\` on each of the seven NormalTimelock-owned converters: RiskFundConverter, four \`*PrimeConverter\`, XVSVaultConverter, and WBNBBurnConverter. (On mainnet WBNBBurnConverter is Guardian-owned and excluded from the migration helper; on BNB Chain Testnet it is NormalTimelock-owned, so it is included here.)
 2. **Upgrade RiskFundV2 implementation** — new impl removes \`updatePoolState\`, \`sweepTokenFromPool\`, and the \`poolAssetsFunds\` mapping (storage slot preserved as \`__deprecatedSlotPoolAssetsFunds\`). \`transferReserveForAuction\` now reads raw balance.
 3. **Accept ownership** on each of the ten new TokenBuyback proxies (deploy script already called \`transferOwnership(NormalTimelock)\`).
-4. **Pause Shortfall auctions** as defense in depth post-upgrade. Isolated pools are wound down on testnet — no live or upcoming auctions exist.
+4. **Grant ACM permissions on each of the ten buybacks**:
+   - Operator (multisig \`${OPERATOR}\`): \`executeBuyback\` + \`forwardBaseAsset\`.
+   - NormalTimelock: \`setDailyCapUsd\` + \`setSlippageEventUsd\` (admin/config so governance can tune cron caps without further VIPs).
+
+   \`setAllowedRouter\` and \`sweepToken\` are \`onlyOwner\` on \`TokenBuyback\`, not ACM-gated — NormalTimelock owns each buyback proxy after step 3 and can call them directly, so no ACM grant is needed for those.
+
+   Router is **not** allowlisted in this VIP, so \`executeBuyback\` will still revert at the router check until governance calls \`setAllowedRouter\` directly; \`forwardBaseAsset\` is callable now.
+5. **Pause Shortfall auctions** as defense in depth post-upgrade. Isolated pools are wound down on testnet — no live or upcoming auctions exist.
 
 The pause step runs **before** the RiskFundV2 upgrade so that RiskFundConverter cannot enter \`convertExactTokens\` against the new impl (which no longer exposes \`updatePoolState\`) between transactions outside this proposal.
 
@@ -96,7 +122,36 @@ Implementation: [VenusProtocol/protocol-reserve PR #158](https://github.com/Venu
         params: [],
       })),
 
-      // 4. Pause Shortfall auctions (defense in depth post-upgrade)
+      // 4a. Operator (multisig) grants: executeBuyback + forwardBaseAsset on each buyback.
+      ...BUYBACKS.flatMap(b => [
+        {
+          target: bsctestnet.ACCESS_CONTROL_MANAGER,
+          signature: "giveCallPermission(address,string,address)",
+          params: [b, EXECUTE_BUYBACK_SIG, OPERATOR],
+        },
+        {
+          target: bsctestnet.ACCESS_CONTROL_MANAGER,
+          signature: "giveCallPermission(address,string,address)",
+          params: [b, FORWARD_BASE_ASSET_SIG, OPERATOR],
+        },
+      ]),
+
+      // 4b. NormalTimelock admin/config grants (ACM-gated only): setDailyCapUsd + setSlippageEventUsd.
+      //     setAllowedRouter and sweepToken are onlyOwner on TokenBuyback and need no ACM grant.
+      ...BUYBACKS.flatMap(b => [
+        {
+          target: bsctestnet.ACCESS_CONTROL_MANAGER,
+          signature: "giveCallPermission(address,string,address)",
+          params: [b, SET_DAILY_CAP_USD_SIG, bsctestnet.NORMAL_TIMELOCK],
+        },
+        {
+          target: bsctestnet.ACCESS_CONTROL_MANAGER,
+          signature: "giveCallPermission(address,string,address)",
+          params: [b, SET_SLIPPAGE_EVENT_USD_SIG, bsctestnet.NORMAL_TIMELOCK],
+        },
+      ]),
+
+      // 5. Pause Shortfall auctions (defense in depth post-upgrade)
       {
         target: SHORTFALL,
         signature: "pauseAuctions()",

--- a/vips/vip-618/bsctestnet.ts
+++ b/vips/vip-618/bsctestnet.ts
@@ -1,26 +1,10 @@
 import { ethers } from "ethers";
-import { NETWORK_ADDRESSES } from "src/networkAddresses";
 import { ProposalType } from "src/types";
 import { makeProposal } from "src/utils";
 
-const { bsctestnet } = NETWORK_ADDRESSES;
-
 export const DEFAULT_PROXY_ADMIN = "0x7877ffd62649b6a1557b55d4c20fcbab17344c91";
-export const PROTOCOL_SHARE_RESERVE = "0x25c7c7D6Bf710949fD7f03364E9BA19a1b3c10E3";
 export const RISK_FUND_V2 = "0x487CeF72dacABD7E12e633bb3B63815a386f7012";
-export const PRIME_LIQUIDITY_PROVIDER = "0xAdeddc73eAFCbed174e6C400165b111b0cb80B7E";
-export const XVS_VAULT_TREASURY = "0x317c6C4c9AA7F87170754DB08b4804dD689B68bF";
-export const PANCAKE_ROUTER = "0xD99D1c33F9fC3444f8101754aBC46c52416550D1";
 export const SHORTFALL = "0x503574a82fE2A9f968d355C8AAc1Ba0481859369";
-
-// ===== Tokens =====
-export const USDT = "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c";
-export const USDC = "0x16227D60f7a0e586C66B005219dfc887D13C9531";
-export const BTCB = "0xA808e341e8e723DC6BA0Bb5204Bafc2330d7B8e4";
-export const ETH = "0x98f7A83361F7Ac8765CcEBAB1425da6b341958a7";
-export const XVS = "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff";
-export const U = "0xcE24439F2D9C6a2289F741120FE202248B666666";
-export const WBNB = "0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd";
 
 // ===== Legacy converters =====
 export const RISK_FUND_CONVERTER = "0x32Fbf7bBbd79355B86741E3181ef8c1D9bD309Bb";
@@ -29,20 +13,31 @@ export const USDC_PRIME_CONVERTER = "0x2ecEdE6989d8646c992344fF6C97c72a3f811A13"
 export const BTCB_PRIME_CONVERTER = "0x989A1993C023a45DA141928921C0dE8fD123b7d1";
 export const ETH_PRIME_CONVERTER = "0xf358650A007aa12ecC8dac08CF8929Be7f72A4D9";
 export const XVS_VAULT_CONVERTER = "0x258f49254C758a0E37DAb148ADDAEA851F4b02a2";
+// WBNBBurnConverter is guardian-owned — not paused by this VIP (mirrors mainnet helper behaviour).
 export const WBNB_BURN_CONVERTER = "0x42DBA48e7cCeB030eC73AaAe29d4A3F0cD4facba";
 export const CONVERTER_NETWORK = "0xC8f2B705d5A2474B390f735A5aFb570e1ce0b2cf";
 
+// Timelock-owned converters that are paused in this VIP (6 — excludes WBNB_BURN_CONVERTER).
+export const LEGACY_CONVERTERS: string[] = [
+  RISK_FUND_CONVERTER,
+  USDT_PRIME_CONVERTER,
+  USDC_PRIME_CONVERTER,
+  BTCB_PRIME_CONVERTER,
+  ETH_PRIME_CONVERTER,
+  XVS_VAULT_CONVERTER,
+];
+
 // ===== New TokenBuyback proxies — TODO: fill from deploy on feat/VPD-1087 =====
-export const RISK_FUND_BUYBACK = ethers.constants.AddressZero; // TODO
-export const USDT_PRIME_BUYBACK = ethers.constants.AddressZero; // TODO
-export const U_PRIME_BUYBACK = ethers.constants.AddressZero; // TODO
-export const XVS_BUYBACK = ethers.constants.AddressZero; // TODO
-export const U_TREASURY_BUYBACK = ethers.constants.AddressZero; // TODO
-export const BTCB_TREASURY_BUYBACK = ethers.constants.AddressZero; // TODO
-export const ETH_TREASURY_BUYBACK = ethers.constants.AddressZero; // TODO
-export const USDT_TREASURY_BUYBACK = ethers.constants.AddressZero; // TODO
-export const USDC_TREASURY_BUYBACK = ethers.constants.AddressZero; // TODO
-export const XVS_TREASURY_BUYBACK = ethers.constants.AddressZero; // TODO
+export const RISK_FUND_BUYBACK = "0x1a063a07853b9bC797E571E54B5Ce632195071fE";
+export const USDT_PRIME_BUYBACK = "0xaAc507Ae5BF60d94e15489fcF75C3AB9D3C6ab55";
+export const U_PRIME_BUYBACK = "0xa9f091C50C2Bd214F757DAF243bCb94A9fE707a4";
+export const XVS_BUYBACK = "0x7b96F9f3A19fd3fbB3b9621058F21d3935Bf5a11";
+export const U_TREASURY_BUYBACK = "0x281d5376723933990815E9EC27D3139903630C5C";
+export const BTCB_TREASURY_BUYBACK = "0x3AC5D1933B0087487A62fAC8944De62FCF39feb6";
+export const ETH_TREASURY_BUYBACK = "0x721CCABeFC18d1e436B3479C9462B1A59988C35d";
+export const USDT_TREASURY_BUYBACK = "0xBCF3Ef25Fb09aA4d39aDA5a737aF7E03B0Fca497";
+export const USDC_TREASURY_BUYBACK = "0x90814cc1e02Bb821De7A280D64dFd7C0f7940fF3";
+export const XVS_TREASURY_BUYBACK = "0x9d8d03EfB3777f97ab1e28D1D88b53aCE2CAE773";
 
 export const BUYBACKS: string[] = [
   RISK_FUND_BUYBACK,
@@ -57,11 +52,7 @@ export const BUYBACKS: string[] = [
   XVS_TREASURY_BUYBACK,
 ];
 
-export const NEW_RISK_FUND_V2_IMPL = ethers.constants.AddressZero; // TODO: fill from deploy
-export const OPERATOR = ethers.constants.AddressZero; // TODO: finance-team cron EOA
-
-const EXECUTE_BUYBACK_SIG = "executeBuyback(address,uint256,uint256,uint256,address,bytes,address)";
-const FORWARD_BASE_ASSET_SIG = "forwardBaseAsset(address,uint256)";
+export const NEW_RISK_FUND_V2_IMPL = "0xAAe9c6412A7EaeB82eD2bA8E9E2bBc27bDa921f6";
 
 export const vip618 = () => {
   const meta = {
@@ -97,9 +88,6 @@ Implementation: [VenusProtocol/protocol-reserve PR #158](https://github.com/Venu
 
   return makeProposal(
     [
-      // PRE-UPGRADE: drain + revoke RiskFundConverter (must precede RiskFundV2 upgrade)
-      // TODO: sweepToken for each held asset, then revokeCallPermission for each grant
-
       // 1. Upgrade RiskFundV2 implementation
       {
         target: DEFAULT_PROXY_ADMIN,
@@ -114,48 +102,14 @@ Implementation: [VenusProtocol/protocol-reserve PR #158](https://github.com/Venu
         params: [],
       })),
 
-      // 3. Allowlist PancakeSwap V2 router
-      ...BUYBACKS.map(b => ({
-        target: b,
-        signature: "setAllowedRouter(address,bool)",
-        params: [PANCAKE_ROUTER, true],
+      // 3. Retire legacy converters — pause conversions (mirrors helper _pauseAllTimelockOwnedConverters)
+      ...LEGACY_CONVERTERS.map(c => ({
+        target: c,
+        signature: "pauseConversion()",
+        params: [],
       })),
 
-      // 4. Grant cron-operator ACM permissions (executeBuyback + forwardBaseAsset × 10)
-      ...BUYBACKS.flatMap(b => [
-        {
-          target: bsctestnet.ACCESS_CONTROL_MANAGER,
-          signature: "giveCallPermission(address,string,address)",
-          params: [b, EXECUTE_BUYBACK_SIG, OPERATOR],
-        },
-        {
-          target: bsctestnet.ACCESS_CONTROL_MANAGER,
-          signature: "giveCallPermission(address,string,address)",
-          params: [b, FORWARD_BASE_ASSET_SIG, OPERATOR],
-        },
-      ]),
-
-      // 5. Drain remaining legacy converters (RiskFundConverter already drained above)
-      // TODO: sweepToken per held asset per converter
-
-      // 6. Revoke ACM permissions on remaining legacy converters
-      // TODO: revokeCallPermission per existing grant
-
-      // 7. Repoint ProtocolShareReserve distribution targets to the 10 new buybacks
-      // TODO: fill [schema, percentage, destination] rows (sum per schema = 1e4)
-      {
-        target: PROTOCOL_SHARE_RESERVE,
-        signature: "addOrUpdateDistributionConfigs((uint8,uint16,address)[])",
-        params: [
-          [
-            // [schema, percentage, destination]
-            // TODO
-          ],
-        ],
-      },
-      // TODO: removeDistributionConfig for any stale rows pointing at retired contracts
-
-      // 8. Defensively pause Shortfall auctions (defense in depth post-upgrade).
+      // 4. Pause Shortfall auctions (defense in depth post-upgrade)
       {
         target: SHORTFALL,
         signature: "pauseAuctions()",


### PR DESCRIPTION
## Summary
- Single-shot VIP-618 for BNB Chain Testnet: retire 7 legacy NormalTimelock-owned converters, upgrade RiskFundV2, take ownership of 10 new TokenBuyback proxies, wire ACM grants for the cron operator and NormalTimelock, and pause Shortfall auctions.
- No follow-up testnet VIP. Router allowlisting, drain, ACM revocations on legacy converters, and PSR distribution-config repointing are intentionally out of scope.

## Changes

### `vips/vip-618/bsctestnet.ts`
- Fill in 10 TokenBuyback proxy addresses + `NEW_RISK_FUND_V2_IMPL` (replaces `AddressZero` TODOs).
- Add `OPERATOR = bsctestnet.GUARDIAN` (testnet multisig serves as buyback cron operator).
- Add sig constants: `EXECUTE_BUYBACK_SIG`, `FORWARD_BASE_ASSET_SIG`, `SET_DAILY_CAP_USD_SIG`, `SET_SLIPPAGE_EVENT_USD_SIG`.
- Include `WBNB_BURN_CONVERTER` in `LEGACY_CONVERTERS` — on bsctestnet it is NormalTimelock-owned (verified on-chain), unlike mainnet where it is Guardian-owned and excluded by the migration helper.
- Reorder commands so pause precedes RiskFundV2 upgrade (RiskFundConverter cannot enter `convertExactTokens` against the new impl, which removes `updatePoolState`).
- 59 commands total: 7 `pauseConversion()` + 1 `upgrade(address,address)` + 10 `acceptOwnership()` + 20 operator ACM grants (`executeBuyback`, `forwardBaseAsset`) + 20 NormalTimelock ACM grants (`setDailyCapUsd`, `setSlippageEventUsd`) + 1 `pauseAuctions()`.
- Rewrite `meta.description` to truthfully reflect executed commands (was listing 8 steps when proposal executed 4); drop misleading "Retired contracts" section.
- Align `meta.title` with the simulation `testVip` title.
- Remove unused exports (`CONVERTER_NETWORK`) and stale `// TODO: fill from deploy` comment.

### `simulations/vip-618/bsctestnet.ts`
- Set `FORK_BLOCK = 106811121` (was `0`).
- Pre-state assertions: `pendingOwner == NormalTimelock` on each buyback; `RiskFundV2` impl ≠ new; legacy converters unpaused; operator has no `executeBuyback`/`forwardBaseAsset` grants; NormalTimelock has no `setDailyCapUsd`/`setSlippageEventUsd` grants; capture Shortfall pause flag informationally.
- Post-state assertions: `RiskFundV2` impl upgraded; `owner == NormalTimelock` on each buyback; 7 legacy converters paused; operator + NormalTimelock ACM grants present; Shortfall auctions paused.
- ACM checks use `initMainnetUser(b)` to impersonate the buyback contract as `msg.sender` (matches mainnet pattern).

## Test plan
- [x] `yarn tsc --noEmit` — clean
- [x] `yarn eslint vips/vip-618/bsctestnet.ts simulations/vip-618/bsctestnet.ts` — clean
- [x] `yarn prettier --check vips/vip-618/bsctestnet.ts simulations/vip-618/bsctestnet.ts` — clean
- [x] `npx hardhat test simulations/vip-618/bsctestnet.ts --fork bsctestnet` — 75/75 passing (18s); covers pre-state, all 59 commands, full VIP lifecycle (proposed → voteable → queued → executed), post-state.
