### PR TITLE
feat: BNB Chain testnet oracle permissions, APRO onboarding and hBNB price

### DIFF
--- a/simulations/vip-654/abi/accessControlManagerTestnet.json
+++ b/simulations/vip-654/abi/accessControlManagerTestnet.json
@@ -1,0 +1,23 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "address", "name": "contractAddress", "type": "address" },
+      { "internalType": "string", "name": "functionSig", "type": "string" }
+    ],
+    "name": "hasPermission",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "account", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "contractAddress", "type": "address" },
+      { "indexed": false, "internalType": "string", "name": "functionSig", "type": "string" }
+    ],
+    "name": "PermissionGranted",
+    "type": "event"
+  }
+]

--- a/simulations/vip-654/bsctestnet.ts
+++ b/simulations/vip-654/bsctestnet.ts
@@ -1,0 +1,91 @@
+import { expect } from "chai";
+import { constants } from "ethers";
+import { parseUnits } from "ethers/lib/utils";
+import { ethers } from "hardhat";
+import { NETWORK_ADDRESSES } from "src/networkAddresses";
+import { expectEvents, initMainnetUser } from "src/utils";
+import { forking, testVip } from "src/vip-framework";
+
+import vip654, {
+  APRO_ORACLE,
+  ATLAS_ORACLE,
+  GUARDIAN,
+  HBNB,
+  HBNB_PRICE,
+  NORMAL_TIMELOCK,
+  ORACLE_PERMISSIONS,
+} from "../../vips/vip-654/bsctestnet";
+import ACM_ABI from "./abi/accessControlManagerTestnet.json";
+import CHAINLINK_ORACLE_ABI from "./abi/chainlinkOracle.json";
+import RESILIENT_ORACLE_ABI from "./abi/resilientOracle.json";
+
+const { bsctestnet } = NETWORK_ADDRESSES;
+
+const FORK_BLOCK = 124639200; // APRO oracle was deployed at block 124639174
+
+const EXPECTED_PERMISSIONS = ORACLE_PERMISSIONS.length * 2; // Guardian (wildcard) + Normal Timelock (APRO)
+
+forking(FORK_BLOCK, async () => {
+  const acm = new ethers.Contract(bsctestnet.ACCESS_CONTROL_MANAGER, ACM_ABI, ethers.provider);
+  const aproOracle = new ethers.Contract(APRO_ORACLE, CHAINLINK_ORACLE_ABI, ethers.provider);
+  const atlasOracle = new ethers.Contract(ATLAS_ORACLE, CHAINLINK_ORACLE_ABI, ethers.provider);
+  const resilientOracle = new ethers.Contract(bsctestnet.RESILIENT_ORACLE, RESILIENT_ORACLE_ABI, ethers.provider);
+
+  describe("Pre-VIP behavior", () => {
+    it("has not accepted ownership of the APRO oracle", async () => {
+      expect(await aproOracle.pendingOwner()).to.equal(NORMAL_TIMELOCK);
+      expect(await aproOracle.owner()).to.not.equal(NORMAL_TIMELOCK);
+    });
+
+    it("does not grant the Guardian the oracle permissions", async () => {
+      for (const signature of ORACLE_PERMISSIONS) {
+        expect(await acm.hasPermission(GUARDIAN, constants.AddressZero, signature)).to.equal(false);
+      }
+    });
+
+    it("does not price hBNB", async () => {
+      await expect(resilientOracle.getPrice(HBNB)).to.be.reverted;
+    });
+  });
+
+  testVip("VIP-654 Testnet", await vip654(), {
+    callbackAfterExecution: async txResponse => {
+      await expectEvents(txResponse, [ACM_ABI], ["PermissionGranted"], [EXPECTED_PERMISSIONS]);
+    },
+  });
+
+  describe("Post-VIP behavior", () => {
+    it("transfers ownership of the APRO oracle to the Normal Timelock", async () => {
+      expect(await aproOracle.owner()).to.equal(NORMAL_TIMELOCK);
+    });
+
+    for (const signature of ORACLE_PERMISSIONS) {
+      it(`grants the Guardian "${signature}" on every oracle`, async () => {
+        expect(await acm.hasPermission(GUARDIAN, constants.AddressZero, signature)).to.equal(true);
+      });
+    }
+
+    for (const signature of ORACLE_PERMISSIONS) {
+      it(`grants the Normal Timelock "${signature}" on the APRO oracle`, async () => {
+        expect(await acm.hasPermission(NORMAL_TIMELOCK, APRO_ORACLE, signature)).to.equal(true);
+      });
+    }
+
+    it("lets the Guardian set a direct price on the APRO oracle through the wildcard", async () => {
+      const guardian = await initMainnetUser(GUARDIAN, parseUnits("1", 18));
+      await aproOracle.connect(guardian).setDirectPrice(HBNB, HBNB_PRICE);
+      expect(await aproOracle.prices(HBNB)).to.equal(HBNB_PRICE);
+    });
+
+    it("sets the hBNB direct price on the Atlas oracle", async () => {
+      expect(await atlasOracle.prices(HBNB)).to.equal(HBNB_PRICE);
+    });
+
+    it("prices hBNB through the ResilientOracle", async () => {
+      const config = await resilientOracle.getTokenConfig(HBNB);
+      expect(config.oracles[0]).to.equal(ATLAS_ORACLE);
+      expect(config.enableFlagsForOracles[0]).to.equal(true);
+      expect(await resilientOracle.getPrice(HBNB)).to.equal(HBNB_PRICE);
+    });
+  });
+});

--- a/vips/vip-654/bsctestnet.ts
+++ b/vips/vip-654/bsctestnet.ts
@@ -1,0 +1,72 @@
+import { constants } from "ethers";
+import { parseUnits } from "ethers/lib/utils";
+import { NETWORK_ADDRESSES } from "src/networkAddresses";
+import { ProposalType } from "src/types";
+import { makeProposal } from "src/utils";
+
+const { bsctestnet } = NETWORK_ADDRESSES;
+
+export const { ACCESS_CONTROL_MANAGER, GUARDIAN, NORMAL_TIMELOCK, RESILIENT_ORACLE } = bsctestnet;
+
+export const ATLAS_ORACLE = "0x7F00af2f30a55e79311392C98fBBfA629D19b3A5";
+export const APRO_ORACLE = "0x309bC6e25672fDBCFa09D76bAA68be59f215f98d"; // pending owner is the Normal Timelock
+
+// Chainlink, RedStone, Atlas and APRO are all ChainlinkOracle instances sharing these ACM-gated setters.
+// setTokenConfig also covers the ResilientOracle and subsumes setOracle/enableOracle there.
+export const ORACLE_PERMISSIONS = ["setTokenConfig(TokenConfig)", "setDirectPrice(address,uint256)"];
+
+// hBNB — DigiFT Hash Global BNB Yield Fund Token. No feed on testnet, so pin a direct price on Atlas.
+export const HBNB = "0xCbfDC27d225Dd3F58DD19C3d37347d043458dcC8";
+export const HBNB_PRICE = parseUnits("613.43", 18); // live BNB/USD reading on testnet at authoring time
+
+export const vip654 = () => {
+  const meta = {
+    version: "v2",
+    title: "VIP-654 [BNB Chain Testnet] Guardian oracle permissions, APRO oracle onboarding and hBNB price",
+    description: `#### Summary
+
+If passed, this VIP will:
+
+1. Grant the Guardian the oracle-configuration permissions (setTokenConfig and setDirectPrice) against the ACM wildcard address, so they apply to every oracle instance.
+2. Onboard the newly deployed APRO oracle: accept its ownership and grant the Normal Timelock permission to configure it.
+3. Configure hBNB (DigiFT Hash Global BNB Yield Fund Token) in the ResilientOracle, priced by the Atlas oracle. Testnet has no hBNB feed, so a fixed direct price is set instead.`,
+    forDescription: "I agree that Venus Protocol should proceed with this proposal",
+    againstDescription: "I do not think that Venus Protocol should proceed with this proposal",
+    abstainDescription: "I am indifferent to whether Venus Protocol proceeds or not",
+  };
+
+  return makeProposal(
+    [
+      // 1. Guardian gets the oracle-configuration surface across every oracle instance.
+      ...ORACLE_PERMISSIONS.map(signature => ({
+        target: ACCESS_CONTROL_MANAGER,
+        signature: "giveCallPermission(address,string,address)",
+        params: [constants.AddressZero, signature, GUARDIAN],
+      })),
+
+      // 2. Onboard the APRO oracle: the Normal Timelock is already its pending owner.
+      { target: APRO_ORACLE, signature: "acceptOwnership()", params: [] },
+      ...ORACLE_PERMISSIONS.map(signature => ({
+        target: ACCESS_CONTROL_MANAGER,
+        signature: "giveCallPermission(address,string,address)",
+        params: [APRO_ORACLE, signature, NORMAL_TIMELOCK],
+      })),
+
+      // 3. hBNB: direct price on the Atlas oracle, routed as MAIN in the ResilientOracle.
+      {
+        target: ATLAS_ORACLE,
+        signature: "setDirectPrice(address,uint256)",
+        params: [HBNB, HBNB_PRICE],
+      },
+      {
+        target: RESILIENT_ORACLE,
+        signature: "setTokenConfig((address,address[3],bool[3],bool))",
+        params: [[HBNB, [ATLAS_ORACLE, constants.AddressZero, constants.AddressZero], [true, false, false], false]],
+      },
+    ],
+    meta,
+    ProposalType.REGULAR,
+  );
+};
+
+export default vip654;


### PR DESCRIPTION
- Configures the APRO oracle on testnet (accepts ownership and grants the Normal Timelock permission to configure it).
- Grants the Guardian the common oracle permissions (`setTokenConfig`, `setDirectPrice`) on testnet, for easier testing.
- Sets an hBNB price on testnet, for FRV testing.
