### PR TITLE
Feat/liquidity hub centrifuge onboarding

### DIFF
--- a/simulations/vip-999/abi/AccessControlManager.json
+++ b/simulations/vip-999/abi/AccessControlManager.json
@@ -1,0 +1,281 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "contractAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "functionSig",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "accountToPermit",
+        "type": "address"
+      }
+    ],
+    "name": "giveCallPermission",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "functionSig",
+        "type": "string"
+      }
+    ],
+    "name": "isAllowedToCall",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "contractAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "functionSig",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "accountToRevoke",
+        "type": "address"
+      }
+    ],
+    "name": "revokeCallPermission",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/simulations/vip-999/abi/Hub.json
+++ b/simulations/vip-999/abi/Hub.json
@@ -1,0 +1,2210 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "BPS_DENOMINATOR",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "EXP_SCALE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MAX_DECIMALS_OFFSET",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MAX_FEE_BPS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MAX_MGMT_FEE_PER_ACCRUAL_BPS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "MAX_REDEEM_FEE_BPS",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "SECONDS_PER_YEAR",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "acceptOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "accessControlManager",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IAccessControlManagerV8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "accrueFees",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "addYieldGroup",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "absoluteCap",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "percentageCapBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "allowance",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "asset",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "convertToAssets",
+    "inputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "convertToShares",
+    "inputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "decimals",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "decreaseAllowance",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "subtractedValue",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "deposit",
+    "inputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositWithConsent",
+    "inputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "consentHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "emergencyReallocate",
+    "inputs": [
+      {
+        "name": "withdraws",
+        "type": "tuple[]",
+        "internalType": "struct IHub.ReallocateLeg[]",
+        "components": [
+          {
+            "name": "yieldGroup",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "resource",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "amount",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      },
+      {
+        "name": "deposits",
+        "type": "tuple[]",
+        "internalType": "struct IHub.ReallocateLeg[]",
+        "components": [
+          {
+            "name": "yieldGroup",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "resource",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "amount",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "feeBps",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "managementBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      },
+      {
+        "name": "performanceBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "feeRecipient",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "highWaterMarkPerShare",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "hubPaused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "increaseAllowance",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "addedValue",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "asset_",
+        "type": "address",
+        "internalType": "contract IERC20Upgradeable"
+      },
+      {
+        "name": "name_",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "symbol_",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "acm_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "decimalsOffset_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "initialMaxWithdrawalSize",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "feeRecipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "lowerMaxWithdrawalSize",
+    "inputs": [
+      {
+        "name": "newSize",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "lowerYieldGroupCap",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "absoluteCap",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "percentageCapBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "maxDeposit",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxMint",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxRedeem",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxWithdraw",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxWithdrawalSize",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "mint",
+    "inputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "mintWithConsent",
+    "inputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "consentHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "outerDepositQueue",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "outerWithdrawQueue",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pauseHub",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "pauseYieldGroup",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "pendingOwner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewDeposit",
+    "inputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewMint",
+    "inputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewRedeem",
+    "inputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewWithdraw",
+    "inputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "raiseMaxWithdrawalSize",
+    "inputs": [
+      {
+        "name": "newSize",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "raiseYieldGroupCap",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "absoluteCap",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "percentageCapBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "reallocate",
+    "inputs": [
+      {
+        "name": "withdraws",
+        "type": "tuple[]",
+        "internalType": "struct IHub.ReallocateLeg[]",
+        "components": [
+          {
+            "name": "yieldGroup",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "resource",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "amount",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      },
+      {
+        "name": "deposits",
+        "type": "tuple[]",
+        "internalType": "struct IHub.ReallocateLeg[]",
+        "components": [
+          {
+            "name": "yieldGroup",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "resource",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "amount",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "redeem",
+    "inputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "redeemFeeBps",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "registeredYieldGroups",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "removeYieldGroup",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "renounceOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setAccessControlManager",
+    "inputs": [
+      {
+        "name": "accessControlManager_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setFeeRecipient",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setManagementFeeBps",
+    "inputs": [
+      {
+        "name": "bps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setOuterDepositQueue",
+    "inputs": [
+      {
+        "name": "queue",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setOuterWithdrawQueue",
+    "inputs": [
+      {
+        "name": "queue",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setPerformanceFeeBps",
+    "inputs": [
+      {
+        "name": "bps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setRedeemFeeBps",
+    "inputs": [
+      {
+        "name": "bps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "sweep",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "symbol",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalAssets",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "total",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalSupply",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transfer",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferOwnership",
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unpauseHub",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unpauseYieldGroup",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdraw",
+    "inputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "yieldGroupConfig",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct IHub.YieldGroupConfig",
+        "components": [
+          {
+            "name": "absoluteCap",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "percentageCapBps",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "paused",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "registered",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "yieldGroupEffectiveCap",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "Approval",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ConsentRecorded",
+    "inputs": [
+      {
+        "name": "supplier",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "consentHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Deposit",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "assets",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DepositRouted",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "FeeRecipientSet",
+    "inputs": [
+      {
+        "name": "oldRecipient",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "newRecipient",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "FeesAccrued",
+    "inputs": [
+      {
+        "name": "managementShares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "performanceShares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "totalShares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "HighWaterMarkUpdated",
+    "inputs": [
+      {
+        "name": "oldHwm",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newHwm",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "HubPauseToggled",
+    "inputs": [
+      {
+        "name": "paused",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ManagementFeeBpsSet",
+    "inputs": [
+      {
+        "name": "oldBps",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "newBps",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MaxWithdrawalSizeLowered",
+    "inputs": [
+      {
+        "name": "oldSize",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newSize",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MaxWithdrawalSizeRaised",
+    "inputs": [
+      {
+        "name": "oldSize",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newSize",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NewAccessControlManager",
+    "inputs": [
+      {
+        "name": "oldAccessControlManager",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "newAccessControlManager",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OuterDepositQueueSet",
+    "inputs": [
+      {
+        "name": "queue",
+        "type": "address[]",
+        "indexed": false,
+        "internalType": "address[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OuterWithdrawQueueSet",
+    "inputs": [
+      {
+        "name": "queue",
+        "type": "address[]",
+        "indexed": false,
+        "internalType": "address[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferStarted",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferred",
+    "inputs": [
+      {
+        "name": "previousOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PerformanceFeeBpsSet",
+    "inputs": [
+      {
+        "name": "oldBps",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "newBps",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RedeemFeeBpsSet",
+    "inputs": [
+      {
+        "name": "oldBps",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      },
+      {
+        "name": "newBps",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Swept",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Withdraw",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "assets",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WithdrawRouted",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "YieldGroupAdded",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "absoluteCap",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "percentageCapBps",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "YieldGroupCapLowered",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "absoluteCap",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "percentageCapBps",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "YieldGroupCapRaised",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "absoluteCap",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "percentageCapBps",
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "YieldGroupPauseToggled",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "paused",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "YieldGroupRemoved",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "YieldGroupSkipped",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "isDeposit",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "HubCapacityExceeded",
+    "inputs": [
+      {
+        "name": "requested",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxAvailable",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "HubInsufficientLiquidity",
+    "inputs": [
+      {
+        "name": "requested",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "available",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "HubPaused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "HubWithdrawCapExceeded",
+    "inputs": [
+      {
+        "name": "requested",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "perRequestCap",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidCap",
+    "inputs": [
+      {
+        "name": "absoluteCap",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "percentageCapBps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidDecimalsOffset",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidFeeBps",
+    "inputs": [
+      {
+        "name": "bps",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidQueue",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotDecreasing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotIncreasing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ReallocateImbalanced",
+    "inputs": [
+      {
+        "name": "withdrawSum",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "depositSum",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "SweepProtectedAsset",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Unauthorized",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "calledContract",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "methodSignature",
+        "type": "string",
+        "internalType": "string"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "WithdrawQueueOmitsFundedYieldGroup",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "YieldGroupAlreadyRegistered",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "YieldGroupAssetMismatch",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "yieldGroupAsset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "hubAsset",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "YieldGroupHasBalance",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "balance",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "YieldGroupNotRegistered",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "YieldGroupPaused",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "YieldGroupUnderfilled",
+    "inputs": [
+      {
+        "name": "yieldGroup",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "requested",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "actual",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroAmount",
+    "inputs": []
+  }
+]

--- a/simulations/vip-999/abi/YieldGroupCentrifuge.json
+++ b/simulations/vip-999/abi/YieldGroupCentrifuge.json
@@ -1,0 +1,1376 @@
+[
+  {
+    "type": "function",
+    "name": "accessControlManager",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "accrue",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "addResource",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "adapter",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "asset",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "cancelDepositRequest",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "cancelRedeemRequest",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "claimCancelDeposit",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "claimCancelRedeem",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "claimDeposit",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "claimRedeem",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "deposit",
+    "inputs": [
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "deposited",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositResource",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "deposited",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "disablePriceGuard",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "dispatchDepositExternal",
+    "inputs": [
+      {
+        "name": "adapter",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "placed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "dispatchWithdrawExternal",
+    "inputs": [
+      {
+        "name": "adapter",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "received",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "forceRemoveResource",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "hub",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "hub_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "asset_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "acm_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "innerDepositQueue",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "innerWithdrawQueue",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxDeposit",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "total",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxWithdraw",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "total",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pauseResource",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "priceGuard",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct IYieldGroupCentrifuge.PriceGuard",
+        "components": [
+          {
+            "name": "enabled",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "maxAge",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "spoke",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "poolId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "scId",
+            "type": "bytes16",
+            "internalType": "bytes16"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "removeResource",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "requestRedeem",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "resourceConfig",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "registered",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "paused",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "adapter",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "resources",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "setInnerDepositQueue",
+    "inputs": [
+      {
+        "name": "queue",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setInnerWithdrawQueue",
+    "inputs": [
+      {
+        "name": "queue",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setPriceGuard",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "spoke",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "poolId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "scId",
+        "type": "bytes16",
+        "internalType": "bytes16"
+      },
+      {
+        "name": "maxAge",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "spotAPYBps",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "sweep",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "totalAssets",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "total",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "unpauseResource",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateResourceAdapter",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "newAdapter",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdraw",
+    "inputs": [
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdrawResource",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "DepositCancelClaimed",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "assets",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DepositCancelRequested",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DepositClaimed",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DepositRouted",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "InnerDepositQueueSet",
+    "inputs": [
+      {
+        "name": "queue",
+        "type": "address[]",
+        "indexed": false,
+        "internalType": "address[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "InnerWithdrawQueueSet",
+    "inputs": [
+      {
+        "name": "queue",
+        "type": "address[]",
+        "indexed": false,
+        "internalType": "address[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PriceGuardDisabled",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PriceGuardSet",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "spoke",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "poolId",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "scId",
+        "type": "bytes16",
+        "indexed": false,
+        "internalType": "bytes16"
+      },
+      {
+        "name": "maxAge",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RedeemCancelClaimed",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RedeemCancelRequested",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RedeemClaimed",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "assets",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RedeemRequested",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourceAccrualFailed",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "adapter",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourceAdapterUpdated",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "oldAdapter",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newAdapter",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourceAdded",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "adapter",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourceForceRemoved",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "writtenOffValue",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "orphanedReceipt",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourcePauseToggled",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "paused",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourceRemoved",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ResourceSkipped",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "isDeposit",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Swept",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WithdrawRouted",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AdapterNotContract",
+    "inputs": [
+      {
+        "name": "adapter",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AdapterUnderfilled",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "requested",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "actual",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "HubAssetMismatch",
+    "inputs": [
+      {
+        "name": "declared",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "hubAsset",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidPriceGuard",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidQueue",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotHub",
+    "inputs": [
+      {
+        "name": "caller",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "OnlySelf",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ResourceAlreadyRegistered",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ResourceAssetMismatch",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "resourceAsset",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "expected",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ResourceBelowMinimumDeposit",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "requested",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "minimum",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ResourceCapacityExceeded",
+    "inputs": [
+      {
+        "name": "requested",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxAvailable",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ResourceHasBalance",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "balance",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ResourceIsPaused",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ResourceLiquidityInsufficient",
+    "inputs": [
+      {
+        "name": "requested",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "available",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ResourceNotContract",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ResourceNotRegistered",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "StalePrice",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "computedAt",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "maxAge",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "SweepProtectedAsset",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SweepProtectedResource",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "Unauthorized",
+    "inputs": [
+      {
+        "name": "caller",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "signature",
+        "type": "string",
+        "internalType": "string"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "WithdrawQueueOmitsFundedResource",
+    "inputs": [
+      {
+        "name": "resource",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroShares",
+    "inputs": []
+  }
+]

--- a/simulations/vip-999/bscmainnet.ts
+++ b/simulations/vip-999/bscmainnet.ts
@@ -9,88 +9,117 @@ import vip999, {
   ACM,
   ADAPTER_CENTRIFUGE,
   CENTRIFUGE_ABSOLUTE_CAP,
+  CENTRIFUGE_CRITICAL_GUARDIAN,
   CENTRIFUGE_GOVERNANCE,
-  CENTRIFUGE_GROUP,
-  CENTRIFUGE_GUARDIAN,
   CENTRIFUGE_KEEPER,
   CENTRIFUGE_PERCENTAGE_CAP_BPS,
-  GUARDIAN,
+  CENTRIFUGE_SPOKE,
+  CENTRIFUGE_VAULTS,
+  CENTRIFUGE_YIELD_GROUP,
+  CRITICAL_GUARDIAN,
+  JAAA_POOL_ID,
+  JAAA_SHARE_CLASS_ID,
+  JAAA_VAULT,
+  JTRSY_POOL_ID,
+  JTRSY_SHARE_CLASS_ID,
   JTRSY_VAULT,
-  KEEPER,
   NORMAL_TIMELOCK,
+  OPERATOR,
   OUTER_DEPOSIT_QUEUE_UNCHANGED,
   OUTER_WITHDRAW_QUEUE,
   PRICE_GUARD_MAX_AGE,
-  USDC,
-  USDC_CORE_GROUP,
-  USDC_FLUX_GROUP,
-  USDC_FRV_GROUP,
-  USDC_HUB,
+  USDT,
+  USDT_CORE_YIELD_GROUP,
+  USDT_FLUX_YIELD_GROUP,
+  USDT_FRV_YIELD_GROUP,
+  USDT_HUB,
 } from "../../vips/vip-999/bscmainnet";
 import ACM_ABI from "./abi/AccessControlManager.json";
 import HUB_ABI from "./abi/Hub.json";
 import CENTRIFUGE_ABI from "./abi/YieldGroupCentrifuge.json";
 
-// DRAFT: the Centrifuge contracts are not deployed, so every CENTRIFUGE_* / JTRSY_* / KEEPER address
-// in the VIP is a dummy and this simulation is EXPECTED TO FAIL until they are swapped in. The
-// structure is final — only the fork block and the address book should need touching.
-const FORK_BLOCK = 116780000;
+// DRAFT: CENTRIFUGE_YIELD_GROUP and ADAPTER_CENTRIFUGE are placeholders, so this simulation fails
+// until they are swapped for the real deployment. Every other address is live and asserted for real.
+const FORK_BLOCK = 117218000;
+
+const SPOKE_ABI = [
+  "function markersPricePoolPerShare(uint64,bytes16) view returns (uint64 computedAt,uint64 maxAge,uint64 validUntil)",
+];
+const VAULT_ABI = [
+  "function asset() view returns (address)",
+  "function poolId() view returns (uint64)",
+  "function scId() view returns (bytes16)",
+];
 
 const addr = (a: string) => ethers.utils.getAddress(a);
 const roleId = (contract: string, sig: string) =>
   ethers.utils.solidityKeccak256(["address", "string"], [contract, sig]);
 
 forking(FORK_BLOCK, async () => {
-  const hub = new ethers.Contract(USDC_HUB, HUB_ABI, ethers.provider);
-  const group = new ethers.Contract(CENTRIFUGE_GROUP, CENTRIFUGE_ABI, ethers.provider);
+  const hub = new ethers.Contract(USDT_HUB, HUB_ABI, ethers.provider);
+  const group = new ethers.Contract(CENTRIFUGE_YIELD_GROUP, CENTRIFUGE_ABI, ethers.provider);
   const acm = new ethers.Contract(ACM, ACM_ABI, ethers.provider);
+  const spoke = new ethers.Contract(CENTRIFUGE_SPOKE, SPOKE_ABI, ethers.provider);
 
   let totalAssetsBefore: BigNumber;
 
   describe("Pre-VIP state", () => {
-    it("the Centrifuge group is deployed and bound to the USDC Hub", async () => {
-      expect(addr(await group.hub())).to.equal(addr(USDC_HUB));
-      expect(addr(await group.asset())).to.equal(addr(USDC));
+    it("both Centrifuge vaults are live, USDT-denominated, and match their declared ids", async () => {
+      for (const [vault, poolId, scId] of [
+        [JTRSY_VAULT, JTRSY_POOL_ID, JTRSY_SHARE_CLASS_ID],
+        [JAAA_VAULT, JAAA_POOL_ID, JAAA_SHARE_CLASS_ID],
+      ]) {
+        const v = new ethers.Contract(vault, VAULT_ABI, ethers.provider);
+        expect(addr(await v.asset())).to.equal(addr(USDT), vault);
+        expect((await v.poolId()).toString()).to.equal(poolId, vault);
+        expect(await v.scId()).to.equal(scId, vault);
+      }
     });
 
-    it("the Centrifuge group is not registered on the Hub", async () => {
-      const cfg = await hub.yieldGroupConfig(CENTRIFUGE_GROUP);
-      expect(cfg.registered).to.equal(false);
+    it("both share classes have a published NAV inside the configured staleness window", async () => {
+      const now = (await ethers.provider.getBlock("latest")).timestamp;
+      for (const [poolId, scId] of [
+        [JTRSY_POOL_ID, JTRSY_SHARE_CLASS_ID],
+        [JAAA_POOL_ID, JAAA_SHARE_CLASS_ID],
+      ]) {
+        const { computedAt } = await spoke.markersPricePoolPerShare(poolId, scId);
+        expect(computedAt.gt(0)).to.equal(true, `${poolId} never published`);
+        expect(now - computedAt.toNumber()).to.be.lessThan(PRICE_GUARD_MAX_AGE, `${poolId} already stale`);
+      }
+    });
+
+    it("the Centrifuge group is bound to the USDT Hub and unregistered on it", async () => {
+      expect(addr(await group.hub())).to.equal(addr(USDT_HUB));
+      expect(addr(await group.asset())).to.equal(addr(USDT));
+      expect((await hub.yieldGroupConfig(CENTRIFUGE_YIELD_GROUP)).registered).to.equal(false);
       expect((await hub.registeredYieldGroups()).map(addr)).to.deep.equal([
-        addr(USDC_CORE_GROUP),
-        addr(USDC_FLUX_GROUP),
-        addr(USDC_FRV_GROUP),
+        addr(USDT_CORE_YIELD_GROUP),
+        addr(USDT_FLUX_YIELD_GROUP),
+        addr(USDT_FRV_YIELD_GROUP),
       ]);
     });
 
-    it("the JTRSY vault is unregistered and the inner queues are empty", async () => {
+    it("no vault is registered on the group and nobody holds a role on it", async () => {
       expect(await group.resources()).to.deep.equal([]);
-      const [registered] = await group.resourceConfig(JTRSY_VAULT);
-      expect(registered).to.equal(false);
-      expect((await group.innerDepositQueue()).length).to.equal(0);
-      expect((await group.innerWithdrawQueue()).length).to.equal(0);
-    });
-
-    it("nobody holds any role on the Centrifuge group yet", async () => {
       for (const sig of CENTRIFUGE_GOVERNANCE) {
-        for (const account of [NORMAL_TIMELOCK, GUARDIAN, KEEPER]) {
-          expect(await acm.hasRole(roleId(CENTRIFUGE_GROUP, sig), account)).to.equal(false, `${account} ${sig}`);
+        for (const account of [NORMAL_TIMELOCK, CRITICAL_GUARDIAN, OPERATOR]) {
+          expect(await acm.hasRole(roleId(CENTRIFUGE_YIELD_GROUP, sig), account)).to.equal(false, `${account} ${sig}`);
         }
       }
     });
 
     it("the Hub's outer queues are the launch queues", async () => {
-      expect((await hub.outerDepositQueue()).map(addr)).to.deep.equal([addr(USDC_CORE_GROUP), addr(USDC_FLUX_GROUP)]);
+      expect((await hub.outerDepositQueue()).map(addr)).to.deep.equal(OUTER_DEPOSIT_QUEUE_UNCHANGED.map(addr));
       expect((await hub.outerWithdrawQueue()).map(addr)).to.deep.equal([
-        addr(USDC_FLUX_GROUP),
-        addr(USDC_CORE_GROUP),
-        addr(USDC_FRV_GROUP),
+        addr(USDT_FLUX_YIELD_GROUP),
+        addr(USDT_CORE_YIELD_GROUP),
+        addr(USDT_FRV_YIELD_GROUP),
       ]);
       totalAssetsBefore = await hub.totalAssets();
     });
   });
 
-  testVip("VIP-999 Onboard the Centrifuge yield group into the USDC Liquidity Hub", await vip999(), {
+  testVip("VIP-999 Onboard the Centrifuge yield group into the USDT Liquidity Hub", await vip999(), {
     callbackAfterExecution: async (tx: TransactionResponse) => {
       await expectEvents(
         tx,
@@ -99,12 +128,11 @@ forking(FORK_BLOCK, async () => {
           "RoleGranted",
           "ResourceAdded",
           "InnerDepositQueueSet",
-          "InnerWithdrawQueueSet",
           "PriceGuardSet",
           "YieldGroupAdded",
           "OuterWithdrawQueueSet",
         ],
-        [CENTRIFUGE_GOVERNANCE.length + CENTRIFUGE_GUARDIAN.length + CENTRIFUGE_KEEPER.length, 1, 1, 1, 1, 1, 1],
+        [CENTRIFUGE_GOVERNANCE.length + CENTRIFUGE_CRITICAL_GUARDIAN.length + CENTRIFUGE_KEEPER.length, 2, 1, 2, 1, 1],
       );
     },
   });
@@ -112,45 +140,51 @@ forking(FORK_BLOCK, async () => {
   describe("Post-VIP state", () => {
     it("grants the Normal Timelock the full governance set", async () => {
       for (const sig of CENTRIFUGE_GOVERNANCE) {
-        expect(await acm.hasRole(roleId(CENTRIFUGE_GROUP, sig), NORMAL_TIMELOCK)).to.equal(true, sig);
+        expect(await acm.hasRole(roleId(CENTRIFUGE_YIELD_GROUP, sig), NORMAL_TIMELOCK)).to.equal(true, sig);
       }
     });
 
-    it("grants the Guardian only the containment subset", async () => {
+    it("grants the Critical Guardian and the keeper only their subsets", async () => {
       for (const sig of CENTRIFUGE_GOVERNANCE) {
-        const expected = CENTRIFUGE_GUARDIAN.includes(sig);
-        expect(await acm.hasRole(roleId(CENTRIFUGE_GROUP, sig), GUARDIAN)).to.equal(expected, sig);
+        expect(await acm.hasRole(roleId(CENTRIFUGE_YIELD_GROUP, sig), CRITICAL_GUARDIAN)).to.equal(
+          CENTRIFUGE_CRITICAL_GUARDIAN.includes(sig),
+          `guardian ${sig}`,
+        );
+        expect(await acm.hasRole(roleId(CENTRIFUGE_YIELD_GROUP, sig), OPERATOR)).to.equal(
+          CENTRIFUGE_KEEPER.includes(sig),
+          `keeper ${sig}`,
+        );
       }
     });
 
-    it("grants the keeper only the four claim functions", async () => {
-      for (const sig of CENTRIFUGE_GOVERNANCE) {
-        const expected = CENTRIFUGE_KEEPER.includes(sig);
-        expect(await acm.hasRole(roleId(CENTRIFUGE_GROUP, sig), KEEPER)).to.equal(expected, sig);
+    it("registers both vaults, sets the inner deposit queue, and leaves the inner withdraw queue unset", async () => {
+      expect((await group.resources()).map(addr)).to.deep.equal(CENTRIFUGE_VAULTS.map(addr));
+      for (const vault of CENTRIFUGE_VAULTS) {
+        const [registered, paused, adapter] = await group.resourceConfig(vault);
+        expect(registered).to.equal(true, vault);
+        expect(paused).to.equal(false, vault);
+        expect(addr(adapter)).to.equal(addr(ADAPTER_CENTRIFUGE), vault);
+      }
+      expect((await group.innerDepositQueue()).map(addr)).to.deep.equal(CENTRIFUGE_VAULTS.map(addr));
+      expect(await group.innerWithdrawQueue()).to.deep.equal([]);
+    });
+
+    it("arms a price guard per vault against the live Spoke", async () => {
+      for (const [vault, poolId, scId] of [
+        [JTRSY_VAULT, JTRSY_POOL_ID, JTRSY_SHARE_CLASS_ID],
+        [JAAA_VAULT, JAAA_POOL_ID, JAAA_SHARE_CLASS_ID],
+      ]) {
+        const guard = await group.priceGuard(vault);
+        expect(guard.enabled).to.equal(true, vault);
+        expect(addr(guard.spoke)).to.equal(addr(CENTRIFUGE_SPOKE), vault);
+        expect(guard.poolId.toString()).to.equal(poolId, vault);
+        expect(guard.scId).to.equal(scId, vault);
+        expect(guard.maxAge).to.equal(PRICE_GUARD_MAX_AGE, vault);
       }
     });
 
-    it("registers the JTRSY vault behind AdapterCentrifuge", async () => {
-      expect((await group.resources()).map(addr)).to.deep.equal([addr(JTRSY_VAULT)]);
-      const [registered, paused, adapter] = await group.resourceConfig(JTRSY_VAULT);
-      expect(registered).to.equal(true);
-      expect(paused).to.equal(false);
-      expect(addr(adapter)).to.equal(addr(ADAPTER_CENTRIFUGE));
-    });
-
-    it("sets both inner queues to the JTRSY vault", async () => {
-      expect((await group.innerDepositQueue()).map(addr)).to.deep.equal([addr(JTRSY_VAULT)]);
-      expect((await group.innerWithdrawQueue()).map(addr)).to.deep.equal([addr(JTRSY_VAULT)]);
-    });
-
-    it("arms the price guard with the configured window", async () => {
-      const guard = await group.priceGuard(JTRSY_VAULT);
-      expect(guard.enabled).to.equal(true);
-      expect(guard.maxAge).to.equal(PRICE_GUARD_MAX_AGE);
-    });
-
-    it("registers the Centrifuge group on the Hub at the configured caps", async () => {
-      const cfg = await hub.yieldGroupConfig(CENTRIFUGE_GROUP);
+    it("registers the group on the Hub at the configured caps", async () => {
+      const cfg = await hub.yieldGroupConfig(CENTRIFUGE_YIELD_GROUP);
       expect(cfg.registered).to.equal(true);
       expect(cfg.paused).to.equal(false);
       expect(cfg.absoluteCap.toString()).to.equal(CENTRIFUGE_ABSOLUTE_CAP);
@@ -162,10 +196,7 @@ forking(FORK_BLOCK, async () => {
       expect((await hub.outerDepositQueue()).map(addr)).to.deep.equal(OUTER_DEPOSIT_QUEUE_UNCHANGED.map(addr));
     });
 
-    it("keeps totalAssets readable (a firing price guard would halt every Hub op)", async () => {
-      // Not asserted equal to the pre-VIP value: the governance flow advances many blocks, so Core
-      // and Flux accrue and fees are taken. The point is that the read still succeeds, and that the
-      // newly added group contributes nothing yet (no deposit has been routed into it).
+    it("keeps totalAssets readable — the armed price guards do not fire", async () => {
       const after = await hub.totalAssets();
       expect(after.gt(0)).to.equal(true);
       expect(after.sub(totalAssetsBefore).abs().lt(totalAssetsBefore.div(1000))).to.equal(true, "TVL moved >0.1%");
@@ -173,11 +204,12 @@ forking(FORK_BLOCK, async () => {
   });
 
   describe("Post-VIP behaviour", () => {
-    it("the keeper can call every claim function and nothing else", async () => {
-      const keeper = await initMainnetUser(KEEPER, ethers.utils.parseEther("1"));
-      // Claims are idempotent no-ops at zero claimable, so passing the ACM gate is the assertion.
-      for (const fn of ["claimDeposit", "claimRedeem", "claimCancelDeposit", "claimCancelRedeem"] as const) {
-        await expect(group.connect(keeper)[fn](JTRSY_VAULT)).to.not.be.reverted;
+    it("the keeper can claim on both vaults and nothing else", async () => {
+      const keeper = await initMainnetUser(OPERATOR, ethers.utils.parseEther("1"));
+      for (const vault of CENTRIFUGE_VAULTS) {
+        for (const fn of ["claimDeposit", "claimRedeem", "claimCancelDeposit", "claimCancelRedeem"] as const) {
+          await expect(group.connect(keeper)[fn](vault)).to.not.be.reverted;
+        }
       }
       await expect(group.connect(keeper).unpauseResource(JTRSY_VAULT)).to.be.revertedWithCustomError(
         group,
@@ -185,13 +217,18 @@ forking(FORK_BLOCK, async () => {
       );
     });
 
-    it("the Guardian can pause the resource but cannot unpause it", async () => {
-      const guardian = await initMainnetUser(GUARDIAN, ethers.utils.parseEther("1"));
-      await expect(group.connect(guardian).pauseResource(JTRSY_VAULT)).to.emit(group, "ResourcePauseToggled");
-      await expect(group.connect(guardian).unpauseResource(JTRSY_VAULT)).to.be.revertedWithCustomError(
+    it("the Critical Guardian can pause a vault but cannot unpause it", async () => {
+      const guardian = await initMainnetUser(CRITICAL_GUARDIAN, ethers.utils.parseEther("1"));
+      await expect(group.connect(guardian).pauseResource(JAAA_VAULT)).to.emit(group, "ResourcePauseToggled");
+      await expect(group.connect(guardian).unpauseResource(JAAA_VAULT)).to.be.revertedWithCustomError(
         group,
         "Unauthorized",
       );
+    });
+
+    it("the group reports zero withdrawable, so the Hub's withdraw cascade skips it", async () => {
+      // Empty inner withdraw queue => maxWithdraw() is idle balance only, which is zero here.
+      expect((await group.maxWithdraw()).toString()).to.equal("0");
     });
 
     it("a random account holds nothing on the group", async () => {

--- a/simulations/vip-999/bscmainnet.ts
+++ b/simulations/vip-999/bscmainnet.ts
@@ -1,0 +1,205 @@
+import { TransactionResponse } from "@ethersproject/providers";
+import { expect } from "chai";
+import { BigNumber } from "ethers";
+import { ethers } from "hardhat";
+import { expectEvents, initMainnetUser } from "src/utils";
+import { forking, testVip } from "src/vip-framework";
+
+import vip999, {
+  ACM,
+  ADAPTER_CENTRIFUGE,
+  CENTRIFUGE_ABSOLUTE_CAP,
+  CENTRIFUGE_GOVERNANCE,
+  CENTRIFUGE_GROUP,
+  CENTRIFUGE_GUARDIAN,
+  CENTRIFUGE_KEEPER,
+  CENTRIFUGE_PERCENTAGE_CAP_BPS,
+  GUARDIAN,
+  JTRSY_VAULT,
+  KEEPER,
+  NORMAL_TIMELOCK,
+  OUTER_DEPOSIT_QUEUE_UNCHANGED,
+  OUTER_WITHDRAW_QUEUE,
+  PRICE_GUARD_MAX_AGE,
+  USDC,
+  USDC_CORE_GROUP,
+  USDC_FLUX_GROUP,
+  USDC_FRV_GROUP,
+  USDC_HUB,
+} from "../../vips/vip-999/bscmainnet";
+import ACM_ABI from "./abi/AccessControlManager.json";
+import HUB_ABI from "./abi/Hub.json";
+import CENTRIFUGE_ABI from "./abi/YieldGroupCentrifuge.json";
+
+// DRAFT: the Centrifuge contracts are not deployed, so every CENTRIFUGE_* / JTRSY_* / KEEPER address
+// in the VIP is a dummy and this simulation is EXPECTED TO FAIL until they are swapped in. The
+// structure is final — only the fork block and the address book should need touching.
+const FORK_BLOCK = 116780000;
+
+const addr = (a: string) => ethers.utils.getAddress(a);
+const roleId = (contract: string, sig: string) =>
+  ethers.utils.solidityKeccak256(["address", "string"], [contract, sig]);
+
+forking(FORK_BLOCK, async () => {
+  const hub = new ethers.Contract(USDC_HUB, HUB_ABI, ethers.provider);
+  const group = new ethers.Contract(CENTRIFUGE_GROUP, CENTRIFUGE_ABI, ethers.provider);
+  const acm = new ethers.Contract(ACM, ACM_ABI, ethers.provider);
+
+  let totalAssetsBefore: BigNumber;
+
+  describe("Pre-VIP state", () => {
+    it("the Centrifuge group is deployed and bound to the USDC Hub", async () => {
+      expect(addr(await group.hub())).to.equal(addr(USDC_HUB));
+      expect(addr(await group.asset())).to.equal(addr(USDC));
+    });
+
+    it("the Centrifuge group is not registered on the Hub", async () => {
+      const cfg = await hub.yieldGroupConfig(CENTRIFUGE_GROUP);
+      expect(cfg.registered).to.equal(false);
+      expect((await hub.registeredYieldGroups()).map(addr)).to.deep.equal([
+        addr(USDC_CORE_GROUP),
+        addr(USDC_FLUX_GROUP),
+        addr(USDC_FRV_GROUP),
+      ]);
+    });
+
+    it("the JTRSY vault is unregistered and the inner queues are empty", async () => {
+      expect(await group.resources()).to.deep.equal([]);
+      const [registered] = await group.resourceConfig(JTRSY_VAULT);
+      expect(registered).to.equal(false);
+      expect((await group.innerDepositQueue()).length).to.equal(0);
+      expect((await group.innerWithdrawQueue()).length).to.equal(0);
+    });
+
+    it("nobody holds any role on the Centrifuge group yet", async () => {
+      for (const sig of CENTRIFUGE_GOVERNANCE) {
+        for (const account of [NORMAL_TIMELOCK, GUARDIAN, KEEPER]) {
+          expect(await acm.hasRole(roleId(CENTRIFUGE_GROUP, sig), account)).to.equal(false, `${account} ${sig}`);
+        }
+      }
+    });
+
+    it("the Hub's outer queues are the launch queues", async () => {
+      expect((await hub.outerDepositQueue()).map(addr)).to.deep.equal([addr(USDC_CORE_GROUP), addr(USDC_FLUX_GROUP)]);
+      expect((await hub.outerWithdrawQueue()).map(addr)).to.deep.equal([
+        addr(USDC_FLUX_GROUP),
+        addr(USDC_CORE_GROUP),
+        addr(USDC_FRV_GROUP),
+      ]);
+      totalAssetsBefore = await hub.totalAssets();
+    });
+  });
+
+  testVip("VIP-999 Onboard the Centrifuge yield group into the USDC Liquidity Hub", await vip999(), {
+    callbackAfterExecution: async (tx: TransactionResponse) => {
+      await expectEvents(
+        tx,
+        [ACM_ABI, CENTRIFUGE_ABI, HUB_ABI],
+        [
+          "RoleGranted",
+          "ResourceAdded",
+          "InnerDepositQueueSet",
+          "InnerWithdrawQueueSet",
+          "PriceGuardSet",
+          "YieldGroupAdded",
+          "OuterWithdrawQueueSet",
+        ],
+        [CENTRIFUGE_GOVERNANCE.length + CENTRIFUGE_GUARDIAN.length + CENTRIFUGE_KEEPER.length, 1, 1, 1, 1, 1, 1],
+      );
+    },
+  });
+
+  describe("Post-VIP state", () => {
+    it("grants the Normal Timelock the full governance set", async () => {
+      for (const sig of CENTRIFUGE_GOVERNANCE) {
+        expect(await acm.hasRole(roleId(CENTRIFUGE_GROUP, sig), NORMAL_TIMELOCK)).to.equal(true, sig);
+      }
+    });
+
+    it("grants the Guardian only the containment subset", async () => {
+      for (const sig of CENTRIFUGE_GOVERNANCE) {
+        const expected = CENTRIFUGE_GUARDIAN.includes(sig);
+        expect(await acm.hasRole(roleId(CENTRIFUGE_GROUP, sig), GUARDIAN)).to.equal(expected, sig);
+      }
+    });
+
+    it("grants the keeper only the four claim functions", async () => {
+      for (const sig of CENTRIFUGE_GOVERNANCE) {
+        const expected = CENTRIFUGE_KEEPER.includes(sig);
+        expect(await acm.hasRole(roleId(CENTRIFUGE_GROUP, sig), KEEPER)).to.equal(expected, sig);
+      }
+    });
+
+    it("registers the JTRSY vault behind AdapterCentrifuge", async () => {
+      expect((await group.resources()).map(addr)).to.deep.equal([addr(JTRSY_VAULT)]);
+      const [registered, paused, adapter] = await group.resourceConfig(JTRSY_VAULT);
+      expect(registered).to.equal(true);
+      expect(paused).to.equal(false);
+      expect(addr(adapter)).to.equal(addr(ADAPTER_CENTRIFUGE));
+    });
+
+    it("sets both inner queues to the JTRSY vault", async () => {
+      expect((await group.innerDepositQueue()).map(addr)).to.deep.equal([addr(JTRSY_VAULT)]);
+      expect((await group.innerWithdrawQueue()).map(addr)).to.deep.equal([addr(JTRSY_VAULT)]);
+    });
+
+    it("arms the price guard with the configured window", async () => {
+      const guard = await group.priceGuard(JTRSY_VAULT);
+      expect(guard.enabled).to.equal(true);
+      expect(guard.maxAge).to.equal(PRICE_GUARD_MAX_AGE);
+    });
+
+    it("registers the Centrifuge group on the Hub at the configured caps", async () => {
+      const cfg = await hub.yieldGroupConfig(CENTRIFUGE_GROUP);
+      expect(cfg.registered).to.equal(true);
+      expect(cfg.paused).to.equal(false);
+      expect(cfg.absoluteCap.toString()).to.equal(CENTRIFUGE_ABSOLUTE_CAP);
+      expect(cfg.percentageCapBps).to.equal(CENTRIFUGE_PERCENTAGE_CAP_BPS);
+    });
+
+    it("appends Centrifuge to the outer withdraw queue and leaves the deposit queue untouched", async () => {
+      expect((await hub.outerWithdrawQueue()).map(addr)).to.deep.equal(OUTER_WITHDRAW_QUEUE.map(addr));
+      expect((await hub.outerDepositQueue()).map(addr)).to.deep.equal(OUTER_DEPOSIT_QUEUE_UNCHANGED.map(addr));
+    });
+
+    it("keeps totalAssets readable (a firing price guard would halt every Hub op)", async () => {
+      // Not asserted equal to the pre-VIP value: the governance flow advances many blocks, so Core
+      // and Flux accrue and fees are taken. The point is that the read still succeeds, and that the
+      // newly added group contributes nothing yet (no deposit has been routed into it).
+      const after = await hub.totalAssets();
+      expect(after.gt(0)).to.equal(true);
+      expect(after.sub(totalAssetsBefore).abs().lt(totalAssetsBefore.div(1000))).to.equal(true, "TVL moved >0.1%");
+    });
+  });
+
+  describe("Post-VIP behaviour", () => {
+    it("the keeper can call every claim function and nothing else", async () => {
+      const keeper = await initMainnetUser(KEEPER, ethers.utils.parseEther("1"));
+      // Claims are idempotent no-ops at zero claimable, so passing the ACM gate is the assertion.
+      for (const fn of ["claimDeposit", "claimRedeem", "claimCancelDeposit", "claimCancelRedeem"] as const) {
+        await expect(group.connect(keeper)[fn](JTRSY_VAULT)).to.not.be.reverted;
+      }
+      await expect(group.connect(keeper).unpauseResource(JTRSY_VAULT)).to.be.revertedWithCustomError(
+        group,
+        "Unauthorized",
+      );
+    });
+
+    it("the Guardian can pause the resource but cannot unpause it", async () => {
+      const guardian = await initMainnetUser(GUARDIAN, ethers.utils.parseEther("1"));
+      await expect(group.connect(guardian).pauseResource(JTRSY_VAULT)).to.emit(group, "ResourcePauseToggled");
+      await expect(group.connect(guardian).unpauseResource(JTRSY_VAULT)).to.be.revertedWithCustomError(
+        group,
+        "Unauthorized",
+      );
+    });
+
+    it("a random account holds nothing on the group", async () => {
+      const [random] = await ethers.getSigners();
+      await expect(group.connect(random).claimDeposit(JTRSY_VAULT)).to.be.revertedWithCustomError(
+        group,
+        "Unauthorized",
+      );
+    });
+  });
+});

--- a/vips/vip-999/bscmainnet.ts
+++ b/vips/vip-999/bscmainnet.ts
@@ -1,0 +1,267 @@
+import { parseUnits } from "ethers/lib/utils";
+import { NETWORK_ADDRESSES } from "src/networkAddresses";
+import { Command, ProposalType } from "src/types";
+import { makeProposal } from "src/utils";
+
+// ===================================================================================================
+// VIP-999 [BNB Chain] — Onboard the Centrifuge yield group (JTRSY) into the USDC Liquidity Hub
+//
+// DRAFT. The Centrifuge family (AdapterCentrifuge, YieldGroupCentrifuge impl, CentrifugeBeacon, and
+// the per-Hub YieldGroupCentrifuge BeaconProxy) is NOT DEPLOYED YET, so every address in the
+// "PLACEHOLDERS" block below is a dummy. Swap them for the real deployment addresses (and re-verify
+// each one on-chain) before this proposal is created.
+//
+// What this does, in order — the ordering is load-bearing:
+//   1. ACM grants on the new yield group: the full 18-signature set to the Normal Timelock, the
+//      operator/containment subset to the Guardian, and the four claim functions to the keeper.
+//   2. addResource(cfVault, AdapterCentrifuge) — must precede the queue setters, which reject an
+//      unregistered resource.
+//   3/4. setInnerDepositQueue / setInnerWithdrawQueue on the group.
+//   5. setPriceGuard — arms the NAV staleness guard for the vault.
+//   6. hub.addYieldGroup — must precede the outer queue setters.
+//   7. setOuterWithdrawQueue on the Hub — must list EVERY registered group or the Hub rejects it, so
+//      the whole queue is rewritten. setOuterDepositQueue is deliberately COMMENTED OUT: Centrifuge
+//      settles asynchronously and is filled by the Operator's reallocate, not by the deposit cascade.
+//
+// Out of scope for this VIP (both must be done off-chain, before/after execution):
+//   - The group proxy must be memberlisted on the JTRSY share token by Centrifuge. Without it
+//     claimDeposit, claimCancelRedeem and requestRedeem all revert. Memberlist entries expire, so a
+//     validUntil has to be agreed with Centrifuge and renewal put on the monitoring rota.
+//   - CentrifugeBeacon ownership is handed to governance inside the deploy broadcast (OZ Ownable is
+//     single-step), so there is no acceptOwnership() here — only a post-deploy check that
+//     beacon.owner() == NORMAL_TIMELOCK.
+// ===================================================================================================
+
+const { ACCESS_CONTROL_MANAGER, NORMAL_TIMELOCK, GUARDIAN } = NETWORK_ADDRESSES.bscmainnet;
+
+export const ACM = ACCESS_CONTROL_MANAGER;
+export { NORMAL_TIMELOCK, GUARDIAN };
+
+// ---------------------------------------------------------------------------------------------------
+// USDC Hub stack — live on mainnet, from VIP-650's address book. USDC on BNB Chain is 18-decimal, so
+// the caps below are in 18-dec units.
+// ---------------------------------------------------------------------------------------------------
+export const USDC = "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d";
+export const USDC_HUB = "0x9D2D9592cF8DFbf59107fAab703d08494BE14617";
+export const USDC_CORE_GROUP = "0x299D9Be7CEfff91c68F13F267d525CFC18e965ef";
+export const USDC_FLUX_GROUP = "0xA65bB4b20542268B64CF08871a98D75342AFE927";
+export const USDC_FRV_GROUP = "0x438388847eE16850Ab4f5b82dc7954c0d043B716";
+
+// ---------------------------------------------------------------------------------------------------
+// PLACEHOLDERS — replace all five before proposing.
+// ---------------------------------------------------------------------------------------------------
+// YieldGroupCentrifuge BeaconProxy for the USDC Hub. Must satisfy asset() == USDC and hub() == USDC_HUB
+// (addYieldGroup reverts YieldGroupAssetMismatch otherwise); the hub/asset/acm binding has no setter.
+export const CENTRIFUGE_GROUP = "0x1111111111111111111111111111111111111111";
+// Stateless AdapterCentrifuge, one per chain, delegatecalled by every Centrifuge group.
+export const ADAPTER_CENTRIFUGE = "0x2222222222222222222222222222222222222222";
+// Centrifuge ERC-7540 JTRSY vault on BNB Chain. asset() must be USDC.
+export const JTRSY_VAULT = "0x3333333333333333333333333333333333333333";
+// Centrifuge Spoke on BNB Chain — read by the price guard for the share-price timestamp.
+export const CENTRIFUGE_SPOKE = "0x4444444444444444444444444444444444444444";
+// Keeper EOA/service that drives the four async claim functions.
+export const KEEPER = "0x5555555555555555555555555555555555555555";
+
+// JTRSY share class identifiers, supplied by Centrifuge. poolId is uint64, scId is bytes16.
+export const JTRSY_POOL_ID = "1";
+export const JTRSY_SHARE_CLASS_ID = "0x00000000000000000000000000000001";
+
+// ---------------------------------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------------------------------
+// Price-guard staleness window, in seconds. Centrifuge publishes NAV discretely, so this must be
+// comfortably longer than the publication cadence: a guard that fires makes totalAssets() revert,
+// which halts every Hub operation.
+export const PRICE_GUARD_MAX_AGE = 7 * 24 * 60 * 60; // 7 days
+
+export const CENTRIFUGE_ABSOLUTE_CAP = parseUnits("5000000", 18).toString(); // 5,000,000 USDC
+export const CENTRIFUGE_PERCENTAGE_CAP_BPS = 2_000; // 20% of Hub TVL
+
+// The withdraw queue is rewritten in full: setOuterWithdrawQueue rejects a queue that omits a
+// registered group. Centrifuge goes LAST — a settled redeem is the slowest path out.
+export const OUTER_WITHDRAW_QUEUE = [USDC_FLUX_GROUP, USDC_CORE_GROUP, USDC_FRV_GROUP, CENTRIFUGE_GROUP];
+
+// The outer DEPOSIT queue is left untouched at its launch value, mirroring how FRV is handled: an
+// async group has no business absorbing a synchronous lender deposit, so Centrifuge is filled by the
+// Operator's `reallocate` instead. Kept here for whenever that decision is revisited.
+// export const OUTER_DEPOSIT_QUEUE = [USDC_CORE_GROUP, USDC_FLUX_GROUP, CENTRIFUGE_GROUP];
+export const OUTER_DEPOSIT_QUEUE_UNCHANGED = [USDC_CORE_GROUP, USDC_FLUX_GROUP];
+
+// ---------------------------------------------------------------------------------------------------
+// ACM role strings — copied verbatim from the _checkAccessAllowed(...) calls in
+// venus-liquidity-hub/contracts/YieldGroup/base/YieldGroupBase.sol (8) and
+// venus-liquidity-hub/contracts/YieldGroup/YieldGroupCentrifuge.sol (10). The role is
+// keccak256(target, string), so a string that merely looks right grants nothing.
+// ---------------------------------------------------------------------------------------------------
+const YIELD_GROUP_BASE = [
+  "addResource(address,address)",
+  "removeResource(address)",
+  "updateResourceAdapter(address,address)",
+  "setInnerDepositQueue(address[])",
+  "setInnerWithdrawQueue(address[])",
+  "pauseResource(address)",
+  "unpauseResource(address)",
+  "sweep(address,address)",
+];
+
+const CENTRIFUGE_ONLY = [
+  "requestRedeem(address,uint256)",
+  "cancelDepositRequest(address)",
+  "cancelRedeemRequest(address)",
+  "claimDeposit(address)",
+  "claimRedeem(address)",
+  "claimCancelDeposit(address)",
+  "claimCancelRedeem(address)",
+  "setPriceGuard(address,address,uint64,bytes16,uint64)",
+  "disablePriceGuard(address)",
+  "forceRemoveResource(address)",
+];
+
+export const CENTRIFUGE_GOVERNANCE = [...YIELD_GROUP_BASE, ...CENTRIFUGE_ONLY];
+
+// Guardian: containment and wind-down with no timelock delay — reorder the queues, pause a resource,
+// and open/cancel async requests. No unpause, no claims, no sweep, no price-guard control.
+export const CENTRIFUGE_GUARDIAN = [
+  "setInnerDepositQueue(address[])",
+  "setInnerWithdrawQueue(address[])",
+  "pauseResource(address)",
+  "requestRedeem(address,uint256)",
+  "cancelDepositRequest(address)",
+  "cancelRedeemRequest(address)",
+];
+
+// Keeper: the four claim functions only. All are idempotent and value-preserving.
+export const CENTRIFUGE_KEEPER = [
+  "claimDeposit(address)",
+  "claimRedeem(address)",
+  "claimCancelDeposit(address)",
+  "claimCancelRedeem(address)",
+];
+
+const grant = (contract: string, sig: string, account: string): Command => ({
+  target: ACM,
+  signature: "giveCallPermission(address,string,address)",
+  params: [contract, sig, account],
+});
+
+export const vip999 = () => {
+  const meta = {
+    version: "v2",
+    title: "VIP-999 [BNB Chain] Onboard the Centrifuge yield group (JTRSY) into the USDC Liquidity Hub",
+    description: `#### Summary
+
+Registers a new **Centrifuge** yield group on the **USDC** Liquidity Hub and wires the Centrifuge
+**JTRSY** ERC-7540 vault into it, so the Hub can allocate USDC into a tokenised T-bill fund alongside
+its existing Core, Flux and FRV groups.
+
+Centrifuge settles asynchronously: a deposit becomes a *request* that Centrifuge fills later, and a
+redemption is a request plus a claim. The yield group therefore carries the extra lifecycle surface
+(\`requestRedeem\`, the two cancellations, four claim functions) plus an optional NAV price-staleness
+guard. Those permissions are split three ways in this proposal.
+
+#### Actions (one atomic transaction, in order)
+
+1. **ACM grants** on the new yield group: the full 18-signature governance set to the **Normal
+   Timelock**; the operator/containment subset (both inner queues, \`pauseResource\`,
+   \`requestRedeem\`, both cancellations) to the **Guardian**; the four claim functions to the
+   **keeper**.
+2. \`addResource(JTRSY vault, AdapterCentrifuge)\` on the group — must precede the queue setters,
+   which reject an unregistered resource.
+3. \`setInnerDepositQueue([JTRSY vault])\`.
+4. \`setInnerWithdrawQueue([JTRSY vault])\`.
+5. \`setPriceGuard(JTRSY vault, Spoke, poolId, scId, ${PRICE_GUARD_MAX_AGE})\` — arms the NAV
+   staleness guard with a ${PRICE_GUARD_MAX_AGE / 86400}-day window.
+6. \`addYieldGroup(Centrifuge group, 5,000,000, 2000 bps)\` on the USDC Hub — must precede the outer
+   queue setters.
+7. \`setOuterWithdrawQueue([Flux, Core, FRV, Centrifuge])\`.
+
+The withdraw queue is rewritten in full because \`setOuterWithdrawQueue\` rejects a queue that omits
+a registered group; Centrifuge is placed last, since a settled Centrifuge redemption is the slowest
+path out.
+
+The Hub's outer **deposit** queue is deliberately **left unchanged**. Centrifuge settles
+asynchronously, so a lender deposit routed into it would sit in \`pendingDepositRequest\` until
+Centrifuge fills it and a keeper claims it. The group is instead filled by the Operator's
+\`reallocate\`, exactly as the FRV groups are.
+
+#### Caps
+
+Absolute **5,000,000** USDC and **20%** of Hub TVL. \`_effectiveCap\` takes the lower of the two, so
+the percentage dimension binds at current TVL.
+
+#### Notes
+
+- The group proxy must be **memberlisted** on the JTRSY share token by Centrifuge. Without that entry
+  \`claimDeposit\`, \`claimCancelRedeem\` and \`requestRedeem\` revert. Memberlist entries expire, so
+  the agreed \`validUntil\` and its renewal belong on the monitoring rota.
+- A firing price guard makes \`totalAssets()\` revert, which halts **every** Hub operation. The
+  ${PRICE_GUARD_MAX_AGE / 86400}-day window is set well above Centrifuge's publication cadence for
+  that reason; \`disablePriceGuard\` is the escape hatch.
+- The CentrifugeBeacon receives governance ownership inside the deploy transaction (OpenZeppelin
+  \`Ownable\` is single-step), so no \`acceptOwnership()\` appears here.
+- The USDT and U Hubs are untouched.`,
+    forDescription: "I agree that Venus Protocol should proceed with this proposal",
+    againstDescription: "I do not think that Venus Protocol should proceed with this proposal",
+    abstainDescription: "I am indifferent to whether Venus Protocol proceeds or not",
+  };
+
+  return makeProposal(
+    [
+      // ────────────────────────────────────────────────────────────────
+      // 1. ACM permissions on the new yield group
+      // ────────────────────────────────────────────────────────────────
+      ...CENTRIFUGE_GOVERNANCE.map(sig => grant(CENTRIFUGE_GROUP, sig, NORMAL_TIMELOCK)),
+      ...CENTRIFUGE_GUARDIAN.map(sig => grant(CENTRIFUGE_GROUP, sig, GUARDIAN)),
+      ...CENTRIFUGE_KEEPER.map(sig => grant(CENTRIFUGE_GROUP, sig, KEEPER)),
+
+      // ────────────────────────────────────────────────────────────────
+      // 2. Register the JTRSY vault, then its inner queues and price guard
+      // ────────────────────────────────────────────────────────────────
+      {
+        target: CENTRIFUGE_GROUP,
+        signature: "addResource(address,address)",
+        params: [JTRSY_VAULT, ADAPTER_CENTRIFUGE],
+      },
+      {
+        target: CENTRIFUGE_GROUP,
+        signature: "setInnerDepositQueue(address[])",
+        params: [[JTRSY_VAULT]],
+      },
+      {
+        target: CENTRIFUGE_GROUP,
+        signature: "setInnerWithdrawQueue(address[])",
+        params: [[JTRSY_VAULT]],
+      },
+      {
+        target: CENTRIFUGE_GROUP,
+        signature: "setPriceGuard(address,address,uint64,bytes16,uint64)",
+        params: [JTRSY_VAULT, CENTRIFUGE_SPOKE, JTRSY_POOL_ID, JTRSY_SHARE_CLASS_ID, PRICE_GUARD_MAX_AGE],
+      },
+
+      // ────────────────────────────────────────────────────────────────
+      // 3. Register the group on the Hub, then rewrite both outer queues
+      // ────────────────────────────────────────────────────────────────
+      {
+        target: USDC_HUB,
+        signature: "addYieldGroup(address,uint256,uint16)",
+        params: [CENTRIFUGE_GROUP, CENTRIFUGE_ABSOLUTE_CAP, CENTRIFUGE_PERCENTAGE_CAP_BPS],
+      },
+      // Deliberately omitted — Centrifuge is filled by the Operator's `reallocate`, not the deposit
+      // cascade. Uncomment (and restore OUTER_DEPOSIT_QUEUE above) only if that changes.
+      // {
+      //   target: USDC_HUB,
+      //   signature: "setOuterDepositQueue(address[])",
+      //   params: [OUTER_DEPOSIT_QUEUE],
+      // },
+      {
+        target: USDC_HUB,
+        signature: "setOuterWithdrawQueue(address[])",
+        params: [OUTER_WITHDRAW_QUEUE],
+      },
+    ],
+    meta,
+    ProposalType.REGULAR,
+  );
+};
+
+export default vip999;

--- a/vips/vip-999/bscmainnet.ts
+++ b/vips/vip-999/bscmainnet.ts
@@ -1,99 +1,84 @@
 import { parseUnits } from "ethers/lib/utils";
 import { NETWORK_ADDRESSES } from "src/networkAddresses";
-import { Command, ProposalType } from "src/types";
+import { ProposalType } from "src/types";
 import { makeProposal } from "src/utils";
 
 // ===================================================================================================
-// VIP-999 [BNB Chain] — Onboard the Centrifuge yield group (JTRSY) into the USDC Liquidity Hub
+// VIP-999 [BNB Chain] — Onboard the Centrifuge yield group (JTRSY + JAAA) into the USDT Liquidity Hub
 //
-// DRAFT. The Centrifuge family (AdapterCentrifuge, YieldGroupCentrifuge impl, CentrifugeBeacon, and
-// the per-Hub YieldGroupCentrifuge BeaconProxy) is NOT DEPLOYED YET, so every address in the
-// "PLACEHOLDERS" block below is a dummy. Swap them for the real deployment addresses (and re-verify
-// each one on-chain) before this proposal is created.
-//
-// What this does, in order — the ordering is load-bearing:
-//   1. ACM grants on the new yield group: the full 18-signature set to the Normal Timelock, the
-//      operator/containment subset to the Guardian, and the four claim functions to the keeper.
-//   2. addResource(cfVault, AdapterCentrifuge) — must precede the queue setters, which reject an
-//      unregistered resource.
-//   3/4. setInnerDepositQueue / setInnerWithdrawQueue on the group.
-//   5. setPriceGuard — arms the NAV staleness guard for the vault.
-//   6. hub.addYieldGroup — must precede the outer queue setters.
-//   7. setOuterWithdrawQueue on the Hub — must list EVERY registered group or the Hub rejects it, so
-//      the whole queue is rewritten. setOuterDepositQueue is deliberately COMMENTED OUT: Centrifuge
-//      settles asynchronously and is filled by the Operator's reallocate, not by the deposit cascade.
-//
-// Out of scope for this VIP (both must be done off-chain, before/after execution):
-//   - The group proxy must be memberlisted on the JTRSY share token by Centrifuge. Without it
-//     claimDeposit, claimCancelRedeem and requestRedeem all revert. Memberlist entries expire, so a
-//     validUntil has to be agreed with Centrifuge and renewal put on the monitoring rota.
-//   - CentrifugeBeacon ownership is handed to governance inside the deploy broadcast (OZ Ownable is
-//     single-step), so there is no acceptOwnership() here — only a post-deploy check that
-//     beacon.owner() == NORMAL_TIMELOCK.
+// DRAFT. Pending before this can be proposed:
+//   1. CENTRIFUGE_YIELD_GROUP — the YieldGroupCentrifuge BeaconProxy for the USDT Hub (not deployed).
+//   2. ADAPTER_CENTRIFUGE — the stateless per-chain adapter (not deployed).
+//   3. Centrifuge must memberlist the yield-group proxy on BOTH share tokens. Both use a
+//      FullRestrictions hook, so without an entry claimDeposit, claimCancelRedeem and requestRedeem
+//      revert. Entries expire — agree a validUntil and put renewal on the monitoring rota.
+// Every other address below is live on BNB Chain and was verified on-chain (see notes inline).
 // ===================================================================================================
 
-const { ACCESS_CONTROL_MANAGER, NORMAL_TIMELOCK, GUARDIAN } = NETWORK_ADDRESSES.bscmainnet;
+const { ACCESS_CONTROL_MANAGER, NORMAL_TIMELOCK, CRITICAL_GUARDIAN } = NETWORK_ADDRESSES.bscmainnet;
 
 export const ACM = ACCESS_CONTROL_MANAGER;
-export { NORMAL_TIMELOCK, GUARDIAN };
+export { NORMAL_TIMELOCK, CRITICAL_GUARDIAN };
+
+// Live Liquidity Hub keeper/operator multisig; holds `reallocate` on every Hub.
+export const OPERATOR = "0x83f426233B358A36953F6951161E76FB7c866a7A";
 
 // ---------------------------------------------------------------------------------------------------
-// USDC Hub stack — live on mainnet, from VIP-650's address book. USDC on BNB Chain is 18-decimal, so
-// the caps below are in 18-dec units.
+// USDT Hub stack — verified: hub.asset() == USDT, registeredYieldGroups() == [core, flux, frv],
+// outerDepositQueue() == [core, flux], outerWithdrawQueue() == [flux, core, frv].
 // ---------------------------------------------------------------------------------------------------
-export const USDC = "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d";
-export const USDC_HUB = "0x9D2D9592cF8DFbf59107fAab703d08494BE14617";
-export const USDC_CORE_GROUP = "0x299D9Be7CEfff91c68F13F267d525CFC18e965ef";
-export const USDC_FLUX_GROUP = "0xA65bB4b20542268B64CF08871a98D75342AFE927";
-export const USDC_FRV_GROUP = "0x438388847eE16850Ab4f5b82dc7954c0d043B716";
+export const USDT = "0x55d398326f99059fF775485246999027B3197955";
+export const USDT_HUB = "0x18AfDACF30F8671021dec4b78297E39d2FE87226";
+export const USDT_CORE_YIELD_GROUP = "0xC9E6ceD9589363f8dC5695Be2C79AB4dDaECC94B";
+export const USDT_FLUX_YIELD_GROUP = "0xe3df38E12E37ED80E1b3ccf2bdf84F9e1527ce14";
+export const USDT_FRV_YIELD_GROUP = "0x621eF38cE0C4e7060fF0bF3D609E3D46EC144bE7";
 
 // ---------------------------------------------------------------------------------------------------
-// PLACEHOLDERS — replace all five before proposing.
+// PENDING DEPLOYMENT — placeholders. The group must satisfy asset() == USDT and hub() == USDT_HUB.
 // ---------------------------------------------------------------------------------------------------
-// YieldGroupCentrifuge BeaconProxy for the USDC Hub. Must satisfy asset() == USDC and hub() == USDC_HUB
-// (addYieldGroup reverts YieldGroupAssetMismatch otherwise); the hub/asset/acm binding has no setter.
-export const CENTRIFUGE_GROUP = "0x1111111111111111111111111111111111111111";
-// Stateless AdapterCentrifuge, one per chain, delegatecalled by every Centrifuge group.
+export const CENTRIFUGE_YIELD_GROUP = "0x1111111111111111111111111111111111111111";
 export const ADAPTER_CENTRIFUGE = "0x2222222222222222222222222222222222222222";
-// Centrifuge ERC-7540 JTRSY vault on BNB Chain. asset() must be USDC.
-export const JTRSY_VAULT = "0x3333333333333333333333333333333333333333";
-// Centrifuge Spoke on BNB Chain — read by the price guard for the share-price timestamp.
-export const CENTRIFUGE_SPOKE = "0x4444444444444444444444444444444444444444";
-// Keeper EOA/service that drives the four async claim functions.
-export const KEEPER = "0x5555555555555555555555555555555555555555";
-
-// JTRSY share class identifiers, supplied by Centrifuge. poolId is uint64, scId is bytes16.
-export const JTRSY_POOL_ID = "1";
-export const JTRSY_SHARE_CLASS_ID = "0x00000000000000000000000000000001";
 
 // ---------------------------------------------------------------------------------------------------
-// Configuration
+// Centrifuge v3 on BNB Chain — all live
 // ---------------------------------------------------------------------------------------------------
-// Price-guard staleness window, in seconds. Centrifuge publishes NAV discretely, so this must be
-// comfortably longer than the publication cadence: a guard that fires makes totalAssets() revert,
-// which halts every Hub operation.
-export const PRICE_GUARD_MAX_AGE = 7 * 24 * 60 * 60; // 7 days
+export const CENTRIFUGE_SPOKE = "0xEC3582fcDc34078a4B7a8c75a5a3AE46f48525aB";
 
-export const CENTRIFUGE_ABSOLUTE_CAP = parseUnits("5000000", 18).toString(); // 5,000,000 USDC
+export const JTRSY_VAULT = "0x6e6B8498415083a4386BE83DD59Edd4366402FFa";
+export const JTRSY_SHARE = "0xa5d465251fBCc907f5Dd6bB2145488DFC6a2627b";
+export const JTRSY_POOL_ID = "281474976710662";
+export const JTRSY_SHARE_CLASS_ID = "0x00010000000000060000000000000001";
+
+export const JAAA_VAULT = "0xcbAfe61d84C6Fb88252a6Adf1C9CB0B9D029cb99";
+export const JAAA_SHARE = "0x58F93d6b1EF2F44eC379Cb975657C132CBeD3B6b";
+export const JAAA_POOL_ID = "281474976710663";
+export const JAAA_SHARE_CLASS_ID = "0x00010000000000070000000000000001";
+
+export const CENTRIFUGE_VAULTS = [JTRSY_VAULT, JAAA_VAULT];
+
+export const PRICE_GUARD_MAX_AGE = 5 * 24 * 60 * 60; // 5 days
+
+export const CENTRIFUGE_ABSOLUTE_CAP = parseUnits("5000000", 18).toString(); // 5,000,000 USDT
 export const CENTRIFUGE_PERCENTAGE_CAP_BPS = 2_000; // 20% of Hub TVL
 
-// The withdraw queue is rewritten in full: setOuterWithdrawQueue rejects a queue that omits a
-// registered group. Centrifuge goes LAST — a settled redeem is the slowest path out.
-export const OUTER_WITHDRAW_QUEUE = [USDC_FLUX_GROUP, USDC_CORE_GROUP, USDC_FRV_GROUP, CENTRIFUGE_GROUP];
+// The group joins the Hub's outer WITHDRAW queue (last) but its own inner withdraw queue is left
+// UNSET
+export const OUTER_WITHDRAW_QUEUE = [
+  USDT_FLUX_YIELD_GROUP,
+  USDT_CORE_YIELD_GROUP,
+  USDT_FRV_YIELD_GROUP,
+  CENTRIFUGE_YIELD_GROUP,
+];
 
-// The outer DEPOSIT queue is left untouched at its launch value, mirroring how FRV is handled: an
-// async group has no business absorbing a synchronous lender deposit, so Centrifuge is filled by the
-// Operator's `reallocate` instead. Kept here for whenever that decision is revisited.
-// export const OUTER_DEPOSIT_QUEUE = [USDC_CORE_GROUP, USDC_FLUX_GROUP, CENTRIFUGE_GROUP];
-export const OUTER_DEPOSIT_QUEUE_UNCHANGED = [USDC_CORE_GROUP, USDC_FLUX_GROUP];
+// Outer DEPOSIT queue unchanged
+export const OUTER_DEPOSIT_QUEUE_UNCHANGED = [USDT_CORE_YIELD_GROUP, USDT_FLUX_YIELD_GROUP];
 
 // ---------------------------------------------------------------------------------------------------
-// ACM role strings — copied verbatim from the _checkAccessAllowed(...) calls in
-// venus-liquidity-hub/contracts/YieldGroup/base/YieldGroupBase.sol (8) and
-// venus-liquidity-hub/contracts/YieldGroup/YieldGroupCentrifuge.sol (10). The role is
-// keccak256(target, string), so a string that merely looks right grants nothing.
+// ACM role strings — verbatim from the _checkAccessAllowed(...) calls in YieldGroupBase.sol (8) and
+// YieldGroupCentrifuge.sol (10). The role is keccak256(target, string).
 // ---------------------------------------------------------------------------------------------------
-const YIELD_GROUP_BASE = [
+export const CENTRIFUGE_GOVERNANCE = [
+  // YieldGroupBase (8)
   "addResource(address,address)",
   "removeResource(address)",
   "updateResourceAdapter(address,address)",
@@ -102,9 +87,7 @@ const YIELD_GROUP_BASE = [
   "pauseResource(address)",
   "unpauseResource(address)",
   "sweep(address,address)",
-];
-
-const CENTRIFUGE_ONLY = [
+  // YieldGroupCentrifuge (10)
   "requestRedeem(address,uint256)",
   "cancelDepositRequest(address)",
   "cancelRedeemRequest(address)",
@@ -117,11 +100,9 @@ const CENTRIFUGE_ONLY = [
   "forceRemoveResource(address)",
 ];
 
-export const CENTRIFUGE_GOVERNANCE = [...YIELD_GROUP_BASE, ...CENTRIFUGE_ONLY];
-
-// Guardian: containment and wind-down with no timelock delay — reorder the queues, pause a resource,
-// and open/cancel async requests. No unpause, no claims, no sweep, no price-guard control.
-export const CENTRIFUGE_GUARDIAN = [
+// Critical Guardian: containment and wind-down, no timelock delay. No unpause, claims, sweep or
+// price-guard control.
+export const CENTRIFUGE_CRITICAL_GUARDIAN = [
   "setInnerDepositQueue(address[])",
   "setInnerWithdrawQueue(address[])",
   "pauseResource(address)",
@@ -130,7 +111,7 @@ export const CENTRIFUGE_GUARDIAN = [
   "cancelRedeemRequest(address)",
 ];
 
-// Keeper: the four claim functions only. All are idempotent and value-preserving.
+// Keeper: the four claim functions only. All idempotent and value-preserving.
 export const CENTRIFUGE_KEEPER = [
   "claimDeposit(address)",
   "claimRedeem(address)",
@@ -138,68 +119,72 @@ export const CENTRIFUGE_KEEPER = [
   "claimCancelRedeem(address)",
 ];
 
-const grant = (contract: string, sig: string, account: string): Command => ({
-  target: ACM,
-  signature: "giveCallPermission(address,string,address)",
-  params: [contract, sig, account],
-});
-
 export const vip999 = () => {
   const meta = {
     version: "v2",
-    title: "VIP-999 [BNB Chain] Onboard the Centrifuge yield group (JTRSY) into the USDC Liquidity Hub",
+    title: "VIP-999 [BNB Chain] Onboard the Centrifuge yield group (JTRSY + JAAA) into the USDT Liquidity Hub",
     description: `#### Summary
 
-Registers a new **Centrifuge** yield group on the **USDC** Liquidity Hub and wires the Centrifuge
-**JTRSY** ERC-7540 vault into it, so the Hub can allocate USDC into a tokenised T-bill fund alongside
-its existing Core, Flux and FRV groups.
+Registers a new **Centrifuge** yield group on the **USDT** Liquidity Hub and wires two Centrifuge v3
+ERC-7540 vaults into it — **JTRSY** (Janus Henderson Anemoy Treasury Fund) and **JAAA** (Janus
+Henderson Anemoy AAA CLO Fund) — so the Hub can allocate USDT into tokenised funds alongside its
+existing Core, Flux and FRV groups.
 
-Centrifuge settles asynchronously: a deposit becomes a *request* that Centrifuge fills later, and a
-redemption is a request plus a claim. The yield group therefore carries the extra lifecycle surface
-(\`requestRedeem\`, the two cancellations, four claim functions) plus an optional NAV price-staleness
-guard. Those permissions are split three ways in this proposal.
+Centrifuge settles asynchronously: a deposit becomes a request Centrifuge fills later, and a
+redemption is a request plus a claim. The yield group carries that extra lifecycle surface
+(\`requestRedeem\`, two cancellations, four claims) plus an optional NAV price-staleness guard, and
+those permissions are split three ways below.
 
 #### Actions (one atomic transaction, in order)
 
 1. **ACM grants** on the new yield group: the full 18-signature governance set to the **Normal
-   Timelock**; the operator/containment subset (both inner queues, \`pauseResource\`,
-   \`requestRedeem\`, both cancellations) to the **Guardian**; the four claim functions to the
-   **keeper**.
-2. \`addResource(JTRSY vault, AdapterCentrifuge)\` on the group — must precede the queue setters,
-   which reject an unregistered resource.
-3. \`setInnerDepositQueue([JTRSY vault])\`.
-4. \`setInnerWithdrawQueue([JTRSY vault])\`.
-5. \`setPriceGuard(JTRSY vault, Spoke, poolId, scId, ${PRICE_GUARD_MAX_AGE})\` — arms the NAV
-   staleness guard with a ${PRICE_GUARD_MAX_AGE / 86400}-day window.
-6. \`addYieldGroup(Centrifuge group, 5,000,000, 2000 bps)\` on the USDC Hub — must precede the outer
-   queue setters.
-7. \`setOuterWithdrawQueue([Flux, Core, FRV, Centrifuge])\`.
-
-The withdraw queue is rewritten in full because \`setOuterWithdrawQueue\` rejects a queue that omits
-a registered group; Centrifuge is placed last, since a settled Centrifuge redemption is the slowest
-path out.
-
-The Hub's outer **deposit** queue is deliberately **left unchanged**. Centrifuge settles
-asynchronously, so a lender deposit routed into it would sit in \`pendingDepositRequest\` until
-Centrifuge fills it and a keeper claims it. The group is instead filled by the Operator's
-\`reallocate\`, exactly as the FRV groups are.
+   Timelock**; the containment subset (both inner queues, \`pauseResource\`, \`requestRedeem\`, both
+   cancellations) to the **Critical Guardian**; the four claim functions to the **keeper**.
+2. \`addResource\` for the JTRSY and JAAA vaults behind the shared \`AdapterCentrifuge\` — must
+   precede the queue setters, which reject an unregistered resource.
+3. \`setInnerDepositQueue([JTRSY, JAAA])\`. The inner **withdraw** queue is deliberately left unset —
+   see the note below.
+4. \`setPriceGuard\` for each vault against the Centrifuge Spoke, with a **5-day** staleness window.
+5. \`addYieldGroup(Centrifuge group, 5,000,000, 2000 bps)\` on the USDT Hub.
+6. \`setOuterWithdrawQueue([Flux, Core, FRV, Centrifuge])\` — rewritten in full, because the Hub
+   rejects a queue that omits a registered group holding a balance.
 
 #### Caps
 
-Absolute **5,000,000** USDC and **20%** of Hub TVL. \`_effectiveCap\` takes the lower of the two, so
-the percentage dimension binds at current TVL.
+Absolute **5,000,000** USDT and **20%** of Hub TVL. \`_effectiveCap\` takes the lower of the two, so
+the percentage dimension binds at the Hub's current TVL.
 
 #### Notes
 
-- The group proxy must be **memberlisted** on the JTRSY share token by Centrifuge. Without that entry
-  \`claimDeposit\`, \`claimCancelRedeem\` and \`requestRedeem\` revert. Memberlist entries expire, so
-  the agreed \`validUntil\` and its renewal belong on the monitoring rota.
-- A firing price guard makes \`totalAssets()\` revert, which halts **every** Hub operation. The
-  ${PRICE_GUARD_MAX_AGE / 86400}-day window is set well above Centrifuge's publication cadence for
-  that reason; \`disablePriceGuard\` is the escape hatch.
+- **User withdrawals skip the invested Centrifuge position.** The group joins the Hub's outer
+  withdraw queue, but its own inner withdraw queue is left unset. \`maxWithdraw()\` sums the inner
+  withdraw queue plus idle balance, so it reports only idle USDT and returns **0** while the funds are
+  in Centrifuge. The Hub clamps each withdraw leg to that figure and skips a zero, so lenders are paid
+  from liquid groups such as Core and Flux while the position keeps counting in \`totalAssets()\`.
+  Once a redeem settles and is claimable, a follow-up VIP calls \`setInnerWithdrawQueue\` — no Hub
+  queue change is needed then.
+- The Hub's outer **deposit** queue is left unchanged. Centrifuge settles asynchronously, so a lender
+  deposit routed into it would sit in \`pendingDepositRequest\` until Centrifuge fills it and a keeper
+  claims it. The group is filled by the Operator's \`reallocate\` instead, as FRV is.
+- Both share tokens use a **FullRestrictions** hook, so Centrifuge must memberlist the yield-group
+  proxy before \`claimDeposit\`, \`claimCancelRedeem\` and \`requestRedeem\` can succeed. Memberlist
+  entries expire; renewal belongs on the monitoring rota.
+- A firing price guard makes \`totalAssets()\` revert, halting **every** Hub operation. The Spoke
+  reports an unbounded validity window for both share classes (\`maxAge\` = \`type(uint64).max\`), so
+  the 5-day figure is derived from the observed publication cadence instead: NAV is published on
+  business days, with 1-day gaps and 4 days worst observed over the last 60. That leaves one day of
+  headroom, so the marker should be monitored; \`disablePriceGuard\` is the escape hatch.
 - The CentrifugeBeacon receives governance ownership inside the deploy transaction (OpenZeppelin
   \`Ownable\` is single-step), so no \`acceptOwnership()\` appears here.
-- The USDT and U Hubs are untouched.`,
+- The USDC and U Hubs are untouched.
+
+#### Contracts
+
+- USDT Hub: ${USDT_HUB}
+- Centrifuge yield group: ${CENTRIFUGE_YIELD_GROUP} · AdapterCentrifuge: ${ADAPTER_CENTRIFUGE}
+- JTRSY vault: ${JTRSY_VAULT} (share ${JTRSY_SHARE})
+- JAAA vault: ${JAAA_VAULT} (share ${JAAA_SHARE})
+- Centrifuge Spoke: ${CENTRIFUGE_SPOKE}`,
     forDescription: "I agree that Venus Protocol should proceed with this proposal",
     againstDescription: "I do not think that Venus Protocol should proceed with this proposal",
     abstainDescription: "I am indifferent to whether Venus Protocol proceeds or not",
@@ -207,54 +192,62 @@ the percentage dimension binds at current TVL.
 
   return makeProposal(
     [
-      // ────────────────────────────────────────────────────────────────
-      // 1. ACM permissions on the new yield group
-      // ────────────────────────────────────────────────────────────────
-      ...CENTRIFUGE_GOVERNANCE.map(sig => grant(CENTRIFUGE_GROUP, sig, NORMAL_TIMELOCK)),
-      ...CENTRIFUGE_GUARDIAN.map(sig => grant(CENTRIFUGE_GROUP, sig, GUARDIAN)),
-      ...CENTRIFUGE_KEEPER.map(sig => grant(CENTRIFUGE_GROUP, sig, KEEPER)),
+      // 1a. Governance: the full set to the Normal Timelock
+      ...CENTRIFUGE_GOVERNANCE.map(sig => ({
+        target: ACM,
+        signature: "giveCallPermission(address,string,address)",
+        params: [CENTRIFUGE_YIELD_GROUP, sig, NORMAL_TIMELOCK],
+      })),
 
-      // ────────────────────────────────────────────────────────────────
-      // 2. Register the JTRSY vault, then its inner queues and price guard
-      // ────────────────────────────────────────────────────────────────
+      // 1b. Containment: the wind-down subset to the Critical Guardian
+      ...CENTRIFUGE_CRITICAL_GUARDIAN.map(sig => ({
+        target: ACM,
+        signature: "giveCallPermission(address,string,address)",
+        params: [CENTRIFUGE_YIELD_GROUP, sig, CRITICAL_GUARDIAN],
+      })),
+
+      // 1c. Claims: the four claim functions to the keeper
+      ...CENTRIFUGE_KEEPER.map(sig => ({
+        target: ACM,
+        signature: "giveCallPermission(address,string,address)",
+        params: [CENTRIFUGE_YIELD_GROUP, sig, OPERATOR],
+      })),
+
+      // 2. Register both vaults, then the inner queues and price guards
       {
-        target: CENTRIFUGE_GROUP,
+        target: CENTRIFUGE_YIELD_GROUP,
         signature: "addResource(address,address)",
         params: [JTRSY_VAULT, ADAPTER_CENTRIFUGE],
       },
       {
-        target: CENTRIFUGE_GROUP,
+        target: CENTRIFUGE_YIELD_GROUP,
+        signature: "addResource(address,address)",
+        params: [JAAA_VAULT, ADAPTER_CENTRIFUGE],
+      },
+      {
+        target: CENTRIFUGE_YIELD_GROUP,
         signature: "setInnerDepositQueue(address[])",
-        params: [[JTRSY_VAULT]],
+        params: [CENTRIFUGE_VAULTS],
       },
       {
-        target: CENTRIFUGE_GROUP,
-        signature: "setInnerWithdrawQueue(address[])",
-        params: [[JTRSY_VAULT]],
-      },
-      {
-        target: CENTRIFUGE_GROUP,
+        target: CENTRIFUGE_YIELD_GROUP,
         signature: "setPriceGuard(address,address,uint64,bytes16,uint64)",
         params: [JTRSY_VAULT, CENTRIFUGE_SPOKE, JTRSY_POOL_ID, JTRSY_SHARE_CLASS_ID, PRICE_GUARD_MAX_AGE],
       },
-
-      // ────────────────────────────────────────────────────────────────
-      // 3. Register the group on the Hub, then rewrite both outer queues
-      // ────────────────────────────────────────────────────────────────
       {
-        target: USDC_HUB,
-        signature: "addYieldGroup(address,uint256,uint16)",
-        params: [CENTRIFUGE_GROUP, CENTRIFUGE_ABSOLUTE_CAP, CENTRIFUGE_PERCENTAGE_CAP_BPS],
+        target: CENTRIFUGE_YIELD_GROUP,
+        signature: "setPriceGuard(address,address,uint64,bytes16,uint64)",
+        params: [JAAA_VAULT, CENTRIFUGE_SPOKE, JAAA_POOL_ID, JAAA_SHARE_CLASS_ID, PRICE_GUARD_MAX_AGE],
       },
-      // Deliberately omitted — Centrifuge is filled by the Operator's `reallocate`, not the deposit
-      // cascade. Uncomment (and restore OUTER_DEPOSIT_QUEUE above) only if that changes.
-      // {
-      //   target: USDC_HUB,
-      //   signature: "setOuterDepositQueue(address[])",
-      //   params: [OUTER_DEPOSIT_QUEUE],
-      // },
+
+      // 3. Register the group on the Hub, then append it to the outer withdraw queue
       {
-        target: USDC_HUB,
+        target: USDT_HUB,
+        signature: "addYieldGroup(address,uint256,uint16)",
+        params: [CENTRIFUGE_YIELD_GROUP, CENTRIFUGE_ABSOLUTE_CAP, CENTRIFUGE_PERCENTAGE_CAP_BPS],
+      },
+      {
+        target: USDT_HUB,
         signature: "setOuterWithdrawQueue(address[])",
         params: [OUTER_WITHDRAW_QUEUE],
       },


### PR DESCRIPTION
## Summary

Draft VIP onboarding a **Centrifuge yield group** into the **USDT Liquidity Hub** on BNB Chain, wiring
two Centrifuge v3 (ERC-7540) tokenised-fund vaults into it — **JTRSY** (Janus Henderson Anemoy Treasury
Fund) and **JAAA** (Janus Henderson Anemoy AAA CLO Fund) — alongside the existing Core, Flux and FRV
groups.

## What the VIP does

34 commands across 6 targets, one atomic transaction, order-dependent.

**1. ACM grants (28)** on the new yield group:
| Holder | Signatures |
| --- | --- |
| Normal Timelock | the full 18-signature set (8 `YieldGroupBase` + 10 `YieldGroupCentrifuge`) |
| Critical Guardian | 6 — both inner queues, `pauseResource`, `requestRedeem`, both cancellations |
| Keeper / Operator | 4 — `claimDeposit`, `claimRedeem`, `claimCancelDeposit`, `claimCancelRedeem` |

The Guardian set is containment and wind-down only: no unpause, no claims, no `sweep`, no price-guard
control, so it can contain but never undo a governance-ordered pause.

**2. Resource registration** — `addResource` for the JTRSY and JAAA vaults behind the shared
`AdapterCentrifuge`. Must precede the queue setters, which reject an unregistered resource.

**3. `setInnerDepositQueue([JTRSY, JAAA])`.** The inner *withdraw* queue is deliberately not set.

**4. `setPriceGuard` per vault** against the live Centrifuge Spoke, **5-day** staleness window.

**5. `addYieldGroup`** on the USDT Hub at **5,000,000 USDT** absolute and **2000 bps** (20% of TVL).
`_effectiveCap` takes the lower, so the percentage dimension binds at the current TVL.

**6. `setOuterWithdrawQueue([Flux, Core, FRV, Centrifuge])`** — rewritten in full, because the Hub
rejects a queue omitting a registered group that holds a balance.

No `acceptOwnership()` appears: the CentrifugeBeacon receives governance ownership inside the deploy
transaction (OpenZeppelin `Ownable` is single-step). The USDC and U Hubs are untouched.


The Spoke reports `maxAge == validUntil == type(uint64).max` for both share classes and
`_enforcePriceGuard` never reads them, so the 5-day window is sized from observed publication cadence
instead: NAV is published on business days — 1-day gaps, 3 days over weekends, **4.00 days worst case
over 60 days of samples**. That leaves one day of headroom.

## Pending before this can be proposed

- [ ] **`CENTRIFUGE_YIELD_GROUP`** — the `YieldGroupCentrifuge` BeaconProxy for the USDT Hub. Not
      deployed;`
- [ ] **`ADAPTER_CENTRIFUGE`** — the stateless per-chain adapter. Not deployed.
- [ ] **Centrifuge must memberlist the group proxy on both share tokens.** 